### PR TITLE
Add PUBGOLF_ENV to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ DB_PORT=5433
 
 ENVOY_ADMIN_PORT=9091
 GRPC_WEB_PORT=8080
+
+# Change to `dev` if not running in docker so that the .env file gets read
+# properly.
+PUBGOLF_ENV=docker_dev


### PR DESCRIPTION
Needed to correctly (not) read .env file from docker env.