### PR TITLE
Dockerized DB Port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 API_HOST=api
 API_PORT=50051
 
+# Change this to `DB_HOST=localhost` if running the API on the host machine
+# instead of via Docker.
+DB_HOST=db
 DB_NAME=pubgolf_dev
 DB_PASSWORD=pubgolf_dev
 DB_USER=pubgolf_dev

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ DB_PORT=5433
 
 ENVOY_ADMIN_PORT=9091
 GRPC_WEB_PORT=8080
+TEST_DB_PORT=5434
 
 # Change to `dev` if not running in docker so that the .env file gets read
 # properly.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Get a `.env` file (`cp .env.example .env`).
 
 Start background services:
 ```
-docker-compose up --build -d db envoy
+docker-compose up -d db envoy
 bin/migrate
 docker-compose up --build -d api
 ```
@@ -40,7 +40,7 @@ Get a `.env` file (`cp .env.example .env`), but set `API_HOST=docker.for.mac.loc
 
 Start background services (database and proxy):
 ```
-docker-compose up --build -d envoy db
+docker-compose up -d envoy db
 ```
 
 Start local instance of API:

--- a/api/lib/server/errors.go
+++ b/api/lib/server/errors.go
@@ -11,7 +11,6 @@ func invalidArgumentError(request interface{}) error {
 	errorMsg := "Missing or invalid argument in request: %s."
 	return status.New(codes.InvalidArgument, fmt.Sprintf(errorMsg, request)).Err()
 }
-}
 
 func invalidAuthError() error {
 	errorMsg := "Invalid or expired authorization."

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,7 @@
+# Bin Scripts
+
+A subset of the `api/bin/` scripts, used to manage the dockerized version of
+the services to support frontend dev.
+
+Note: the `migrate` and `reset-db` scripts here are hardcoded to run against
+`localhost`, so you need to use the `api/bin/` versions to migrate remote envs.

--- a/bin/migrate
+++ b/bin/migrate
@@ -6,6 +6,6 @@ docker run -v "${PWD}/api/db/migrations:/migrations" \
 --network host \
 migrate/migrate \
 -path=/migrations/ \
--database "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST:-localhost}:"\
+-database "postgres://${DB_USER}:${DB_PASSWORD}@localhost:"\
 "${DB_PORT:-5432}/${DB_NAME}?sslmode=${DB_SSL_MODE:-disable}" \
 up

--- a/bin/reset-db
+++ b/bin/reset-db
@@ -6,7 +6,7 @@ docker run -v "${PWD}/api/db/migrations:/migrations" \
 --network host \
 migrate/migrate \
 -path=/migrations/ \
--database "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST:-localhost}:"\
+-database "postgres://${DB_USER}:${DB_PASSWORD}@localhost:"\
 "${DB_PORT:-5432}/${DB_NAME}?sslmode=${DB_SSL_MODE:-disable}" \
 down -all=true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: postgres
     restart: always
     ports:
-      - "5433:5432"
+      - "${DB_PORT}:${DB_PORT}"
     networks:
       - data_access
     volumes:
@@ -44,16 +44,18 @@ services:
       POSTGRES_NAME: "${DB_NAME}"
       POSTGRES_USER: "${DB_USER}"
       POSTGRES_PASSWORD: "${DB_PASSWORD}"
+      POSTGRES_PORT: "${DB_PORT}"
   testdb:
     image: postgres
     ports:
-      - "5434:5432"
+      - "${TEST_DB_PORT}:${TEST_DB_PORT}"
     networks:
       - data_access
     environment:
       POSTGRES_NAME: pubgolf_test
       POSTGRES_USER: pubgolf_test
       POSTGRES_PASSWORD: pubgolf_test
+      POSTGRES_PORT: "${TEST_DB_PORT}"
 networks:
   proxy_pass:
   data_access:


### PR DESCRIPTION
Patch the (non-api) migration scripts so that they'll run while the `.env` file is set up for accessing the DB via Docker. Additionally, parameterize the ports for the DB and test DB.