### PR TITLE
Update Package Scripts to Remove Postinstall

### DIFF
--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -19,7 +19,7 @@ COPY ./proto /home/node/proto
 COPY ./web-app /home/node/web-app
 
 WORKDIR /home/node/web-app
-RUN npm install -g npx && npm install --unsafe-perm
-RUN npm run sapper:build
+RUN npm install -g npx && npm install
+RUN npm run build
 
 CMD ["node", "__sapper__/build/index.js"]

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -5,20 +5,20 @@
   "scripts": {
     "cy:run": "cypress run",
     "cy:open": "cypress open",
+    "deps:make": "run-p tailwind protoc",
     "protoc": "mkdir -p src/proto/ && run-s protoc:clean protoc:build",
     "protoc:build": "protoc -I=../proto ../proto/*.proto --js_out=import_style=commonjs:./src/proto --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:./src/proto",
     "protoc:clean": "rm -f ./src/proto/*",
     "sapper:build": "sapper build",
     "sapper:dev": "sapper dev",
-
+    "sapper:export": "sapper export",
     "tailwind": "npx tailwind build static/tailwind.config.css -o static/tailwind.css",
-    "build": "run-s protoc sapper:build",
-    "dev": "run-s protoc tailwind sapper:dev",
-    "export": "sapper export",
-    "start": "node __sapper__/build",
-    "test": "run-p --race dev cy:run",
 
-    "postinstall": "run-p tailwind protoc"
+    "build": "run-s deps:make sapper:build",
+    "dev": "run-s deps:make sapper:dev",
+    "export": "run-s deps:make sapper:export",
+    "start": "node __sapper__/build",
+    "test": "run-p --race dev cy:run"
   },
   "dependencies": {
     "compression": "^1.7.1",


### PR DESCRIPTION
Finally tracked down the source of the `web-app` container build issues...the `postinstall` script was unable to run without the `--unsafe-perm` flag, due to the node process running as root within Docker.

I had added this flag directly on master to check that the GH Action now passes (it does 👍), but would prefer to just refactor the `package.json` to not require a `postinstall`.