### PR TITLE
Linter Fixes for API Server

### DIFF
--- a/api/e2e/rpc.go
+++ b/api/e2e/rpc.go
@@ -10,17 +10,17 @@ import (
 )
 
 var funcMap map[string]func(pg.APIClient) = map[string]func(pg.APIClient){
-	"1": RegisterPlayer,
-	"2": RequestPlayerLogin,
-	"3": PlayerLogin,
-	"4": GetSchedule,
-	"5": GetScores,
-	"6": GetScoresForPlayer,
+	"1": registerPlayer,
+	"2": requestPlayerLogin,
+	"3": playerLogin,
+	"4": getSchedule,
+	"5": getScores,
+	"6": getScoresForPlayer,
 }
 
-func RegisterPlayer(client pg.APIClient) {
+func registerPlayer(client pg.APIClient) {
 	eventKey := getInput("eventKey", "starts-in-30m")
-	phoneNumber := getInput("phoneNumber", "+5551231234")
+	phoneNumber := getInput("phoneNumber", "+15551231234")
 	name := getInput("name", "Eric Morris")
 
 	league := pg.League_NONE
@@ -42,9 +42,9 @@ func RegisterPlayer(client pg.APIClient) {
 	logResponse(r, err)
 }
 
-func RequestPlayerLogin(client pg.APIClient) {
+func requestPlayerLogin(client pg.APIClient) {
 	eventKey := getInput("eventKey", "starts-in-30m")
-	phoneNumber := getInput("phoneNumber", "+5551231234")
+	phoneNumber := getInput("phoneNumber", "+15551231234")
 
 	log.Println("Making call to RequestPlayerLogin")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -56,9 +56,9 @@ func RequestPlayerLogin(client pg.APIClient) {
 	logResponse(r, err)
 }
 
-func PlayerLogin(client pg.APIClient) {
+func playerLogin(client pg.APIClient) {
 	eventKey := getInput("eventKey", "starts-in-30m")
-	phoneNumber := getInput("phoneNumber", "+5551231234")
+	phoneNumber := getInput("phoneNumber", "+15551231234")
 	authCode, err := getInputAsUInt32("authCode", 111111)
 	if err != nil {
 		log.Printf("Could not parse input as a number: %s", err)
@@ -76,7 +76,7 @@ func PlayerLogin(client pg.APIClient) {
 	logResponse(r, err)
 }
 
-func GetSchedule(client pg.APIClient) {
+func getSchedule(client pg.APIClient) {
 	authToken := getInput("authToken", "00000000-0000-4000-a000-300000000000")
 	eventKey := getInput("eventKey", "current")
 
@@ -89,7 +89,7 @@ func GetSchedule(client pg.APIClient) {
 	logResponse(r, err)
 }
 
-func GetScores(client pg.APIClient) {
+func getScores(client pg.APIClient) {
 	authToken := getInput("authToken", "00000000-0000-4000-a000-300000000000")
 	eventKey := getInput("eventKey", "current")
 
@@ -102,7 +102,7 @@ func GetScores(client pg.APIClient) {
 	logResponse(r, err)
 }
 
-func GetScoresForPlayer(client pg.APIClient) {
+func getScoresForPlayer(client pg.APIClient) {
 	authToken := getInput("authToken", "00000000-0000-4000-a000-300000000000")
 	eventKey := getInput("eventKey", "current")
 	playerID := getInput("eventKey", "00000000-0000-4000-a000-200000000000")

--- a/api/lib/db/events.go
+++ b/api/lib/db/events.go
@@ -6,6 +6,7 @@ import (
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
+// GetEventID accepts an `eventKey` and returns a corresponding event ID to bypass joins in later queries.
 func GetEventID(tx *sql.Tx, eventKey *string) (string, error) {
 	eventIDRow := tx.QueryRow(`
 		SELECT id
@@ -22,6 +23,7 @@ func GetEventID(tx *sql.Tx, eventKey *string) (string, error) {
 	return eventID, err
 }
 
+// GetScheduleForEvent returns the venue list for an event.
 func GetScheduleForEvent(tx *sql.Tx, eventID *string) (pg.VenueList, error) {
 	venueList := pg.VenueList{}
 	rows, err := tx.Query(`

--- a/api/lib/db/players.go
+++ b/api/lib/db/players.go
@@ -7,7 +7,7 @@ import (
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
-// CreatePlayer inserts a new player into the databse in an unconfirmed state.
+// CreatePlayer inserts a new player into the database in an unconfirmed state.
 func CreatePlayer(tx *sql.Tx, eventID *string, name *string, league pg.League, phoneNumber *string,
 	randCode uint32) error {
 	_, err := tx.Exec(`

--- a/api/lib/db/players.go
+++ b/api/lib/db/players.go
@@ -7,8 +7,9 @@ import (
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
-func CreatePlayer(tx *sql.Tx, eventID *string, name *string, league pg.League,
-	phoneNumber *string, randCode uint32) error {
+// CreatePlayer inserts a new player into the databse in an unconfirmed state.
+func CreatePlayer(tx *sql.Tx, eventID *string, name *string, league pg.League, phoneNumber *string,
+	randCode uint32) error {
 	_, err := tx.Exec(`
 		INSERT INTO
 		players(
@@ -29,8 +30,8 @@ func CreatePlayer(tx *sql.Tx, eventID *string, name *string, league pg.League,
 	return err
 }
 
-func CheckPlayerExistsByPhoneNumber(tx *sql.Tx, eventID *string,
-	phoneNumber *string) (
+// CheckPlayerExistsByPhoneNumber returns true if the `eventID` + `phoneNumber` combination is valid.
+func CheckPlayerExistsByPhoneNumber(tx *sql.Tx, eventID *string, phoneNumber *string) (
 	bool, error) {
 	playerCountRow := tx.QueryRow(`
 		SELECT COUNT(*)
@@ -48,14 +49,13 @@ func CheckPlayerExistsByPhoneNumber(tx *sql.Tx, eventID *string,
 	return playerCount == 1, err
 }
 
-func GetPlayerName(tx *sql.Tx, eventID *string, playerID *string) (
-	string, error) {
+// GetPlayerName returns the display name for a given `playerID`.
+func GetPlayerName(tx *sql.Tx, playerID *string) (string, error) {
 	nameRow := tx.QueryRow(`
 		SELECT name
 		FROM players
-		WHERE event_id = $1
-			AND id = $2
-		`, eventID, playerID)
+		WHERE id = $2
+		`, playerID)
 	var name string
 	err := nameRow.Scan(&name)
 
@@ -66,8 +66,8 @@ func GetPlayerName(tx *sql.Tx, eventID *string, playerID *string) (
 	return name, err
 }
 
-func SetAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string,
-	authCode uint32) error {
+// SetAuthCode updates the auth code (and expiration time) for a player's auth code.
+func SetAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string, authCode uint32) error {
 	_, err := tx.Exec(`
 		UPDATE players
 		SET
@@ -80,8 +80,8 @@ func SetAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string,
 	return err
 }
 
-func ValidateAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string,
-	authCode uint32) (bool, error) {
+// ValidateAuthCode confirms the validity (equality and expiration window) of a provided `authCode` for a given user.
+func ValidateAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string, authCode uint32) (bool, error) {
 	authCodeCreatedAtRow := tx.QueryRow(`
 		SELECT auth_code_created_at
 		FROM players
@@ -100,11 +100,11 @@ func ValidateAuthCode(tx *sql.Tx, eventID *string, phoneNumber *string,
 		return false, err
 	}
 	codeExpiration, err := time.ParseDuration("10m")
-	isValid := authCodeCreatedAt != time.Time{} &&
-		time.Now().Sub(authCodeCreatedAt) < codeExpiration
+	isValid := authCodeCreatedAt != time.Time{} && time.Now().Sub(authCodeCreatedAt) < codeExpiration
 	return isValid, err
 }
 
+// GenerateAuthToken unsets a user's auth code and generates a fresh auth token.
 func GenerateAuthToken(tx *sql.Tx, eventID *string, phoneNumber *string) error {
 	_, err := tx.Exec(`
 		UPDATE players
@@ -119,6 +119,7 @@ func GenerateAuthToken(tx *sql.Tx, eventID *string, phoneNumber *string) error {
 	return err
 }
 
+// GetAuthToken returns a user's auth token.
 func GetAuthToken(tx *sql.Tx, eventID *string, phoneNumber *string) (string, error) {
 	authTokenRow := tx.QueryRow(`
 		SELECT auth_token
@@ -131,6 +132,8 @@ func GetAuthToken(tx *sql.Tx, eventID *string, phoneNumber *string) (string, err
 	return authToken, err
 }
 
+// ValidateAuthToken returns the corresponding event ID and player ID for a valid `authToken`. In the event of an
+// invalid `authToken`, an empty string will be returned as both IDs.
 func ValidateAuthToken(tx *sql.Tx, authToken *string) (string, string, error) {
 	var eventID, playerID string
 	row := tx.QueryRow(`

--- a/api/lib/db/scores.go
+++ b/api/lib/db/scores.go
@@ -7,8 +7,8 @@ import (
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
-func GetPlayerScores(tx *sql.Tx, eventID *string, playerID *string) (
-	[]*pg.Score, error) {
+// GetPlayerScores returns all scores for a given player and event.
+func GetPlayerScores(tx *sql.Tx, eventID *string, playerID *string) ([]*pg.Score, error) {
 	scores := make([]*pg.Score, 0)
 	rows, err := tx.Query(`
 		WITH event_timeslots AS (
@@ -109,6 +109,7 @@ func GetPlayerScores(tx *sql.Tx, eventID *string, playerID *string) (
 	return scores, nil
 }
 
+// GetScoreboardBestOf9 returns scores for all players that are eligible for the "Best of 9" category.
 func GetScoreboardBestOf9(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	return getScoreboard(tx, eventID, `
 		SELECT
@@ -129,6 +130,8 @@ func GetScoreboardBestOf9(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	`)
 }
 
+// GetScoreboardBestOf5 returns scores for all players that are eligible for the "Best of 5" category (but not eligible
+// for "Best of 9").
 func GetScoreboardBestOf5(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	return getScoreboard(tx, eventID, `
 		SELECT
@@ -149,6 +152,8 @@ func GetScoreboardBestOf5(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	`)
 }
 
+// GetScoreboardIncomplete returns scores for all players that aren't eligible for either the "Best of 9" or "Best of 5"
+// categories.
 func GetScoreboardIncomplete(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	return getScoreboard(tx, eventID, `
 		SELECT
@@ -168,6 +173,7 @@ func GetScoreboardIncomplete(tx *sql.Tx, eventID *string) ([]*pg.Score, error) {
 	`)
 }
 
+// getScoreboard is a helper function to wrap common logic for all of the scoreboard fetchers.
 func getScoreboard(tx *sql.Tx, eventID *string, scoreboardQuery string) (
 	[]*pg.Score, error) {
 	scores := make([]*pg.Score, 0)

--- a/api/lib/server/display.go
+++ b/api/lib/server/display.go
@@ -7,9 +7,9 @@ import (
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
-func (server *APIServer) GetSchedule(ctx context.Context,
-	req *pg.GetScheduleRequest) (*pg.GetScheduleReply, error) {
-	tx, eventID, _, err := validateAuthenticatedRequest(server, ctx, &req.EventKey)
+// GetSchedule returns a list of venues and transisiton times for an event.
+func (server *APIServer) GetSchedule(ctx context.Context, req *pg.GetScheduleRequest) (*pg.GetScheduleReply, error) {
+	tx, eventID, _, err := validateAuthenticatedRequest(ctx, server, &req.EventKey)
 	if err != nil {
 		return nil, err
 	}
@@ -24,9 +24,9 @@ func (server *APIServer) GetSchedule(ctx context.Context,
 	return &pg.GetScheduleReply{VenueList: &venueList}, nil
 }
 
-func (server *APIServer) GetScores(ctx context.Context,
-	req *pg.GetScoresRequest) (*pg.GetScoresReply, error) {
-	tx, eventID, _, err := validateAuthenticatedRequest(server, ctx, &req.EventKey)
+// GetScores returns an event's overall leaderboard.
+func (server *APIServer) GetScores(ctx context.Context, req *pg.GetScoresRequest) (*pg.GetScoresReply, error) {
+	tx, eventID, _, err := validateAuthenticatedRequest(ctx, server, &req.EventKey)
 	if err != nil {
 		return nil, err
 	}
@@ -65,19 +65,19 @@ func (server *APIServer) GetScores(ctx context.Context,
 	}, nil
 }
 
-func (server *APIServer) GetScoresForPlayer(ctx context.Context,
-	req *pg.GetScoresForPlayerRequest) (*pg.GetScoresForPlayerReply, error) {
+// GetScoresForPlayer all scores for the requested player.
+func (server *APIServer) GetScoresForPlayer(ctx context.Context, req *pg.GetScoresForPlayerRequest) (
+	*pg.GetScoresForPlayerReply, error) {
 	if invalidIDFormat(&req.PlayerID) {
 		return nil, invalidArgumentError()
 	}
 
-	tx, eventID, _, err := validateAuthenticatedRequest(server, ctx,
-		&req.EventKey)
+	tx, eventID, _, err := validateAuthenticatedRequest(ctx, server, &req.EventKey)
 	if err != nil {
 		return nil, err
 	}
 
-	playerName, err := db.GetPlayerName(tx, &eventID, &req.PlayerID)
+	playerName, err := db.GetPlayerName(tx, &req.PlayerID)
 	if err != nil {
 		tx.Rollback()
 		return nil, temporaryServerError(err)

--- a/api/lib/server/helpers.go
+++ b/api/lib/server/helpers.go
@@ -18,8 +18,10 @@ var uuidFormat *regexp.Regexp = regexp.MustCompile(
 var phoneNumberFormat *regexp.Regexp = regexp.MustCompile(
 	"^\\+[1-9]\\d{1,14}$")
 
-func validateAuthenticatedRequest(server *APIServer, ctx context.Context,
-	eventKey *string) (*sql.Tx, string, string, error) {
+// validateAuthenticatedRequest extracts an auth token from the request header and ensures that it's valid for the
+// given `eventKey`, returning the associated player ID and event ID.
+func validateAuthenticatedRequest(ctx context.Context, server *APIServer, eventKey *string) (*sql.Tx, string, string,
+	error) {
 	if isEmpty(eventKey) {
 		return nil, "", "", invalidArgumentError()
 	}
@@ -62,8 +64,8 @@ func validateAuthenticatedRequest(server *APIServer, ctx context.Context,
 	return tx, eventID, playerID, nil
 }
 
-func validateUnauthenticatedRequest(server *APIServer, eventKey *string) (
-	*sql.Tx, string, error) {
+// validateUnauthenticatedRequest ensures that the given `eventKey` is valid.
+func validateUnauthenticatedRequest(server *APIServer, eventKey *string) (*sql.Tx, string, error) {
 	if isEmpty(eventKey) {
 		return nil, "", invalidArgumentError()
 	}
@@ -89,8 +91,7 @@ func validateUnauthenticatedRequest(server *APIServer, eventKey *string) (
 func getAuthTokenFromHeader(ctx context.Context) (string, error) {
 	metadata, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", status.Errorf(codes.DataLoss,
-			"Error reading 'authorization' header.")
+		return "", status.Errorf(codes.DataLoss, "Error reading 'authorization' header.")
 	}
 
 	authHeader, ok := metadata["authorization"]

--- a/api/lib/server/server.go
+++ b/api/lib/server/server.go
@@ -3,14 +3,15 @@ package server
 import (
 	"database/sql"
 
+	// Needed to import the Postgres driver correctly.
 	_ "github.com/lib/pq"
 
 	pg "github.com/escavelo/pubgolf/api/proto/pubgolf"
 )
 
+// APIServer is a struct for passing global context, such as the databse handle.
 type APIServer struct {
 	DB *sql.DB
-	// Include a default implementation of all RPC methods, even if we don't get
-	// around to defining it.
+	// Include a default implementation of all RPC methods, even if we don't get around to defining it.
 	pg.UnimplementedAPIServer
 }

--- a/api/lib/sms/sms.go
+++ b/api/lib/sms/sms.go
@@ -10,21 +10,22 @@ import (
 	"strings"
 )
 
+// SendAuthCodeSms handles populating the auth message template with the provided `authCode` and sends it to
+// `phoneNumber` via SMS. The `phoneNumber` argument is expected to be in valid E.164 format:
+// https://www.twilio.com/docs/glossary/what-e164
 func SendAuthCodeSms(phoneNumber *string, authCode uint32) error {
 	smsContent := fmt.Sprintf("Your pubgolf.co auth code is: %d", authCode)
 	logAction := "Logging"
 	var err error = nil
 
-	if os.Getenv("TWILIO_FROM_NUM") != "" && os.Getenv("TWILIO_ACCOUNT_SID") !=
-		"" && os.Getenv("TWILIO_AUTH_TOKEN") != "" {
+	if os.Getenv("TWILIO_FROM_NUM") != "" && os.Getenv("TWILIO_ACCOUNT_SID") != "" && os.Getenv("TWILIO_AUTH_TOKEN") !=
+		"" {
 		logAction = "Sending"
 		msgReader := formatMessage(phoneNumber, smsContent)
-		err = sendRequest(os.Getenv("TWILIO_ACCOUNT_SID"),
-			os.Getenv("TWILIO_AUTH_TOKEN"), msgReader)
+		err = sendRequest(os.Getenv("TWILIO_ACCOUNT_SID"), os.Getenv("TWILIO_AUTH_TOKEN"), msgReader)
 	}
 
-	log.Printf("%s text message to %s:\n==========\n%s\n==========",
-		logAction, *phoneNumber, smsContent)
+	log.Printf("%s text message to %s:\n==========\n%s\n==========", logAction, *phoneNumber, smsContent)
 
 	return err
 }
@@ -41,8 +42,7 @@ func formatMessage(phoneNumber *string, smsContent string) strings.Reader {
 func sendRequest(accountSid string, authToken string,
 	msgDataReader strings.Reader) error {
 	client := &http.Client{}
-	urlStr := "https://api.twilio.com/2010-04-01/Accounts/" + accountSid +
-		"/Messages.json"
+	urlStr := fmt.Sprintf("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", accountSid)
 	req, err := http.NewRequest("POST", urlStr, &msgDataReader)
 	if err != nil {
 		return err

--- a/api/main.go
+++ b/api/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DEFAULT_PORT = "50051"
+	defaultPort = "50051"
 )
 
 func loadEnv() {
@@ -28,9 +28,8 @@ func loadEnv() {
 
 	log.Printf("Running as PUBGOLF_ENV of %s", env)
 
-	// In dev, we assume we're running in the monorepo, in which case the .env is
-	// at the repo root. Otherwise, we're probably in the docker environment and
-	// can access values as real env vars.
+	// In dev, we assume we're running in the monorepo, in which case the .env is at the repo root. Otherwise, we're
+	// probably in the docker environment and can access values as real env vars.
 	if strings.ToLower(env) == "dev" {
 		if err := godotenv.Load("../.env"); err != nil {
 			log.Fatal("Error loading .env file")
@@ -104,7 +103,7 @@ func main() {
 	server := initServer(db)
 	port := os.Getenv("API_PORT")
 	if port == "" {
-		port = DEFAULT_PORT
+		port = defaultPort
 	}
 	bindServer(server, port)
 }

--- a/proto/pubgolf.proto
+++ b/proto/pubgolf.proto
@@ -12,16 +12,14 @@ service API {
 
   // Player accounts are per-event.
   rpc RegisterPlayer (RegisterPlayerRequest) returns (RegisterPlayerReply) {}
-  rpc RequestPlayerLogin (RequestPlayerLoginRequest)
-    returns (RequestPlayerLoginReply) {}
+  rpc RequestPlayerLogin (RequestPlayerLoginRequest) returns (RequestPlayerLoginReply) {}
   rpc PlayerLogin (PlayerLoginRequest) returns (PlayerLoginReply) {}
 
   // Display endpoints - secured via auth token
 
   rpc GetSchedule (GetScheduleRequest) returns (GetScheduleReply) {}
   rpc GetScores (GetScoresRequest) returns (GetScoresReply) {}
-  rpc GetScoresForPlayer (GetScoresForPlayerRequest)
-    returns (GetScoresForPlayerReply) {}
+  rpc GetScoresForPlayer (GetScoresForPlayerRequest) returns (GetScoresForPlayerReply) {}
 
   // User action endpoints - secured via auth token
 
@@ -99,9 +97,8 @@ message CreateOrUpdateScoreRequest {
   string playerID = 2;
   int32 strokes = 3;
 
-  // TODO: Figure out how to handle bonus and penalty. I think we can probably
-  // include this field in the proto, share it across the player server and the
-  // admin server and just ignore it in the player-facing endpoints.
+  // TODO: Figure out how to handle bonus and penalty. I think we can probably include this field in the proto, share it
+  // across the player server and the admin server and just ignore it in the player-facing endpoints.
   // sint32 adjustments = 4;
 
   // TODO: Comments?


### PR DESCRIPTION
Mostly trivial changes:

- Increased word wrap col to 120 chars to make code a bit more readable (even if GitHub diffs suffer a little on small screens)
- Made some exported functions package-private
- Added doc comments to all exported functions
- Reordered a couple arguments and removed a few unused ones
- Fixed the formatting of default phone numbers in the test client