### PR TITLE
test(rpc): add unit tests for public RPC guards and handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 data/
+.worktrees/

--- a/api/internal/lib/dao/testhelpers.go
+++ b/api/internal/lib/dao/testhelpers.go
@@ -1,5 +1,12 @@
 package dao
 
+import (
+	"context"
+	"time"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+)
+
 // MockDAOCall holds data to allow mocking a DAO query method.
 type MockDAOCall struct {
 	ShouldCall bool
@@ -11,5 +18,53 @@ type MockDAOCall struct {
 func (c MockDAOCall) Bind(m *MockQueryProvider, name string) {
 	if c.ShouldCall {
 		m.On(name, c.Args...).Return(c.Return...)
+	}
+}
+
+// noop is a context function that does nothing, for use in mock async results.
+var noop = func(context.Context) {}
+
+// MockScoringCriteriaAsyncResult creates a ScoringCriteriaAsyncResult with pre-populated data and a no-op query.
+func MockScoringCriteriaAsyncResult(scores []models.ScoringInput, err error) *ScoringCriteriaAsyncResult {
+	return &ScoringCriteriaAsyncResult{
+		asyncResult: asyncResult{query: noop},
+		Scores:      scores,
+		Err:         err,
+	}
+}
+
+// MockEventStartTimeAsyncResult creates an EventStartTimeAsyncResult with pre-populated data and a no-op query.
+func MockEventStartTimeAsyncResult(startTime time.Time, err error) *EventStartTimeAsyncResult {
+	return &EventStartTimeAsyncResult{
+		asyncResult: asyncResult{query: noop},
+		StartTime:   startTime,
+		Err:         err,
+	}
+}
+
+// MockEventScheduleAsyncResult creates an EventScheduleAsyncResult with pre-populated data and a no-op query.
+func MockEventScheduleAsyncResult(schedule []VenueStop, err error) *EventScheduleAsyncResult {
+	return &EventScheduleAsyncResult{
+		asyncResult: asyncResult{query: noop},
+		Schedule:    schedule,
+		Err:         err,
+	}
+}
+
+// MockAdjustmentTemplatesByStageIDAsyncResult creates an AdjustmentTemplatesByStageIDAsyncResult with pre-populated data and a no-op query.
+func MockAdjustmentTemplatesByStageIDAsyncResult(templates []models.AdjustmentTemplate, err error) *AdjustmentTemplatesByStageIDAsyncResult {
+	return &AdjustmentTemplatesByStageIDAsyncResult{
+		asyncResult: asyncResult{query: noop},
+		Templates:   templates,
+		Err:         err,
+	}
+}
+
+// MockScoreByPlayerStageAsyncResult creates a ScoreByPlayerStageAsyncResult with pre-populated data and a no-op query.
+func MockScoreByPlayerStageAsyncResult(score models.Score, err error) *ScoreByPlayerStageAsyncResult {
+	return &ScoreByPlayerStageAsyncResult{
+		asyncResult: asyncResult{query: noop},
+		Score:       score,
+		Err:         err,
 	}
 }

--- a/api/internal/lib/rpc/public/client_version_test.go
+++ b/api/internal/lib/rpc/public/client_version_test.go
@@ -1,0 +1,44 @@
+package public
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestClientVersion(t *testing.T) {
+	t.Parallel()
+
+	mockDAO := new(dao.MockQueryProvider)
+	s := makeTestServer(mockDAO)
+
+	t.Run("current version returns OK", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := s.ClientVersion(context.Background(), connect.NewRequest(&apiv1.ClientVersionRequest{ClientVersion: 1}))
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ClientVersionResponse_VERSION_STATUS_OK, resp.Msg.GetVersionStatus())
+	})
+
+	t.Run("version above current returns OK", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := s.ClientVersion(context.Background(), connect.NewRequest(&apiv1.ClientVersionRequest{ClientVersion: 100}))
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ClientVersionResponse_VERSION_STATUS_OK, resp.Msg.GetVersionStatus())
+	})
+
+	t.Run("version below min returns INCOMPATIBLE", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := s.ClientVersion(context.Background(), connect.NewRequest(&apiv1.ClientVersionRequest{ClientVersion: 0}))
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ClientVersionResponse_VERSION_STATUS_INCOMPATIBLE, resp.Msg.GetVersionStatus())
+	})
+}

--- a/api/internal/lib/rpc/public/complete_player_login_test.go
+++ b/api/internal/lib/rpc/public/complete_player_login_test.go
@@ -1,0 +1,98 @@
+package public
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+	"github.com/pubgolf/pubgolf/api/internal/lib/sms"
+)
+
+func TestCompletePlayerLogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Valid login", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		phoneNum := models.PhoneNum("+15551234567")
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		authToken := models.AuthTokenFromULID(ulid.Make())
+
+		mockMes.On("CheckVerification", mock.Anything, phoneNum, "12345678").Return(true, nil)
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, phoneNum}, Return: []any{true, nil}}.Bind(mockDAO, "VerifyPhoneNumber")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, phoneNum}, Return: []any{dao.GenerateAuthTokenResult{PlayerID: playerID, AuthToken: authToken}, nil}}.Bind(mockDAO, "GenerateAuthToken")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID}, Return: []any{models.Player{ID: playerID, Name: "Test"}, nil}}.Bind(mockDAO, "PlayerByID")
+
+		resp, err := s.CompletePlayerLogin(t.Context(), connect.NewRequest(&apiv1.CompletePlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+			AuthCode:    "12345678",
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, authToken.String(), resp.Msg.GetAuthToken())
+		assert.Equal(t, "Test", resp.Msg.GetPlayer().GetData().GetName())
+	})
+
+	t.Run("Invalid phone format", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		_, err := s.CompletePlayerLogin(t.Context(), connect.NewRequest(&apiv1.CompletePlayerLoginRequest{
+			PhoneNumber: "invalid",
+			AuthCode:    "12345678",
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("Invalid auth code format", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		_, err := s.CompletePlayerLogin(t.Context(), connect.NewRequest(&apiv1.CompletePlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+			AuthCode:    "abc",
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("SMS check fails (wrong code)", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		phoneNum := models.PhoneNum("+15551234567")
+
+		mockMes.On("CheckVerification", mock.Anything, phoneNum, "12345678").Return(false, nil)
+
+		_, err := s.CompletePlayerLogin(t.Context(), connect.NewRequest(&apiv1.CompletePlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+			AuthCode:    "12345678",
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}

--- a/api/internal/lib/rpc/public/get_scores_for_category_test.go
+++ b/api/internal/lib/rpc/public/get_scores_for_category_test.go
@@ -1,0 +1,132 @@
+package public
+
+import (
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestGetScoresForCategory(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	gameCtx := middleware.ContextWithPlayerID(t.Context(), playerID)
+	eventKey := "test-event"
+	eventID := models.EventIDFromULID(ulid.Make())
+
+	player1ID := models.PlayerIDFromULID(ulid.Make())
+	player2ID := models.PlayerIDFromULID(ulid.Make())
+
+	schedule := []dao.VenueStop{
+		{VenueKey: models.VenueKeyFromUInt32(1), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(2), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(3), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(4), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(5), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(6), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(7), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(8), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(9), Duration: 30 * time.Minute},
+	}
+
+	mockAsyncQueries := func(mockDAO *dao.MockQueryProvider, scores []models.ScoringInput) {
+		dao.MockDAOCall{ShouldCall: true, Args: []any{eventID, models.ScoringCategoryPubGolfNineHole}, Return: []any{
+			dao.MockScoringCriteriaAsyncResult(scores, nil),
+		}}.Bind(mockDAO, "ScoringCriteriaAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{eventID}, Return: []any{
+			dao.MockEventStartTimeAsyncResult(time.Now().Add(-30*time.Minute), nil),
+		}}.Bind(mockDAO, "EventStartTimeAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{eventID}, Return: []any{
+			dao.MockEventScheduleAsyncResult(schedule, nil),
+		}}.Bind(mockDAO, "EventScheduleAsync")
+	}
+
+	t.Run("Valid category with scores", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockEventIDByKey(mockDAO, eventKey, eventID)
+		mockPlayerRegisteredForEvent(mockDAO, playerID, eventID)
+		mockAsyncQueries(mockDAO, []models.ScoringInput{
+			{PlayerID: player1ID, Name: "Alice", TotalPoints: 10, VerifiedScores: 1},
+			{PlayerID: player2ID, Name: "Bob", TotalPoints: 15, VerifiedScores: 1},
+		})
+
+		resp, err := s.GetScoresForCategory(gameCtx, connect.NewRequest(&apiv1.GetScoresForCategoryRequest{
+			EventKey: eventKey,
+			Category: apiv1.ScoringCategory_SCORING_CATEGORY_PUB_GOLF_NINE_HOLE,
+		}))
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Msg.GetScoreBoard().GetScores(), 2)
+	})
+
+	t.Run("Empty leaderboard", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockEventIDByKey(mockDAO, eventKey, eventID)
+		mockPlayerRegisteredForEvent(mockDAO, playerID, eventID)
+		mockAsyncQueries(mockDAO, []models.ScoringInput{})
+
+		resp, err := s.GetScoresForCategory(gameCtx, connect.NewRequest(&apiv1.GetScoresForCategoryRequest{
+			EventKey: eventKey,
+			Category: apiv1.ScoringCategory_SCORING_CATEGORY_PUB_GOLF_NINE_HOLE,
+		}))
+
+		require.NoError(t, err)
+		assert.Empty(t, resp.Msg.GetScoreBoard().GetScores())
+	})
+
+	t.Run("Invalid category", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockEventIDByKey(mockDAO, eventKey, eventID)
+		mockPlayerRegisteredForEvent(mockDAO, playerID, eventID)
+
+		_, err := s.GetScoresForCategory(gameCtx, connect.NewRequest(&apiv1.GetScoresForCategoryRequest{
+			EventKey: eventKey,
+			Category: apiv1.ScoringCategory(9999),
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("Not registered for event", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{false, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+
+		_, err := s.GetScoresForCategory(gameCtx, connect.NewRequest(&apiv1.GetScoresForCategoryRequest{
+			EventKey: eventKey,
+			Category: apiv1.ScoringCategory_SCORING_CATEGORY_PUB_GOLF_NINE_HOLE,
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}

--- a/api/internal/lib/rpc/public/get_submit_score_form_test.go
+++ b/api/internal/lib/rpc/public/get_submit_score_form_test.go
@@ -1,0 +1,164 @@
+package public
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestGetSubmitScoreForm(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	gameCtx := middleware.ContextWithPlayerID(t.Context(), playerID)
+	eventKey := "test-event"
+	eventID := models.EventIDFromULID(ulid.Make())
+	stageID := models.StageIDFromULID(ulid.Make())
+	adjTemplateID := models.AdjustmentTemplateIDFromULID(ulid.Make())
+
+	schedule := []dao.VenueStop{
+		{VenueKey: models.VenueKeyFromUInt32(1), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(2), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(3), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(4), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(5), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(6), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(7), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(8), Duration: 30 * time.Minute},
+		{VenueKey: models.VenueKeyFromUInt32(9), Duration: 30 * time.Minute},
+	}
+
+	mockCommonGuards := func(mockDAO *dao.MockQueryProvider, category models.ScoringCategory) {
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{true, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{category, nil}}.Bind(mockDAO, "PlayerCategoryForEvent")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, models.VenueKeyFromUInt32(1)}, Return: []any{stageID, nil}}.Bind(mockDAO, "StageIDByVenueKey")
+		// EventScheduleAsync is always constructed (line 49 of handler), even for NineHole.
+		dao.MockDAOCall{ShouldCall: true, Args: []any{eventID}, Return: []any{
+			dao.MockEventScheduleAsyncResult(schedule, nil),
+		}}.Bind(mockDAO, "EventScheduleAsync")
+	}
+
+	t.Run("9-hole, no existing score", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockCommonGuards(mockDAO, models.ScoringCategoryPubGolfNineHole)
+
+		templates := []models.AdjustmentTemplate{
+			{ID: adjTemplateID, Label: "Bonus", Value: -1, VenueSpecific: false},
+		}
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{stageID}, Return: []any{
+			dao.MockAdjustmentTemplatesByStageIDAsyncResult(templates, nil),
+		}}.Bind(mockDAO, "AdjustmentTemplatesByStageIDAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{playerID, stageID}, Return: []any{
+			dao.MockScoreByPlayerStageAsyncResult(models.Score{}, sql.ErrNoRows),
+		}}.Bind(mockDAO, "ScoreByPlayerStageAsync")
+
+		resp, err := s.GetSubmitScoreForm(gameCtx, connect.NewRequest(&apiv1.GetSubmitScoreFormRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ScoreStatus_SCORE_STATUS_REQUIRED, resp.Msg.GetStatus())
+		assert.NotNil(t, resp.Msg.GetForm())
+	})
+
+	t.Run("9-hole, existing score", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockCommonGuards(mockDAO, models.ScoringCategoryPubGolfNineHole)
+
+		templates := []models.AdjustmentTemplate{
+			{ID: adjTemplateID, Label: "Bonus", Value: -1, VenueSpecific: false},
+		}
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{stageID}, Return: []any{
+			dao.MockAdjustmentTemplatesByStageIDAsyncResult(templates, nil),
+		}}.Bind(mockDAO, "AdjustmentTemplatesByStageIDAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{playerID, stageID}, Return: []any{
+			dao.MockScoreByPlayerStageAsyncResult(models.Score{Value: 5, IsVerified: false}, nil),
+		}}.Bind(mockDAO, "ScoreByPlayerStageAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, stageID}, Return: []any{[]models.Adjustment{}, nil}}.Bind(mockDAO, "AdjustmentsByPlayerStage")
+
+		resp, err := s.GetSubmitScoreForm(gameCtx, connect.NewRequest(&apiv1.GetSubmitScoreFormRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ScoreStatus_SCORE_STATUS_SUBMITTED_EDITABLE, resp.Msg.GetStatus())
+		assert.Equal(t, "Edit Your Score", resp.Msg.GetForm().GetLabel())
+	})
+
+	t.Run("5-hole on even index (optional stage)", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		venueKey2 := models.VenueKeyFromUInt32(2)
+		stageID2 := models.StageIDFromULID(ulid.Make())
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{true, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{models.ScoringCategoryPubGolfFiveHole, nil}}.Bind(mockDAO, "PlayerCategoryForEvent")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, venueKey2}, Return: []any{stageID2, nil}}.Bind(mockDAO, "StageIDByVenueKey")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{stageID2}, Return: []any{
+			dao.MockAdjustmentTemplatesByStageIDAsyncResult([]models.AdjustmentTemplate{}, nil),
+		}}.Bind(mockDAO, "AdjustmentTemplatesByStageIDAsync")
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{playerID, stageID2}, Return: []any{
+			dao.MockScoreByPlayerStageAsyncResult(models.Score{}, sql.ErrNoRows),
+		}}.Bind(mockDAO, "ScoreByPlayerStageAsync")
+
+		schedule := []dao.VenueStop{
+			{VenueKey: models.VenueKeyFromUInt32(1), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(2), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(3), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(4), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(5), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(6), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(7), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(8), Duration: 30 * time.Minute},
+			{VenueKey: models.VenueKeyFromUInt32(9), Duration: 30 * time.Minute},
+		}
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{eventID}, Return: []any{
+			dao.MockEventScheduleAsyncResult(schedule, nil),
+		}}.Bind(mockDAO, "EventScheduleAsync")
+
+		resp, err := s.GetSubmitScoreForm(gameCtx, connect.NewRequest(&apiv1.GetSubmitScoreFormRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 2,
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ScoreStatus_SCORE_STATUS_OPTIONAL, resp.Msg.GetStatus())
+	})
+}

--- a/api/internal/lib/rpc/public/guards_test.go
+++ b/api/internal/lib/rpc/public/guards_test.go
@@ -1,0 +1,326 @@
+package public
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+var errTestDB = errors.New("test db error")
+
+func TestGuardInferredPlayerID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns player ID from context", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		got, err := s.guardInferredPlayerID(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, playerID, got)
+	})
+
+	t.Run("errors when context has no player ID", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		_, err := s.guardInferredPlayerID(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+}
+
+func TestGuardPlayerIDMatchesSelf(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed ID when matching", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		got, err := s.guardPlayerIDMatchesSelf(ctx, playerID.String())
+		require.NoError(t, err)
+		assert.Equal(t, playerID, got)
+	})
+
+	t.Run("errors on mismatched ID", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		contextID := models.PlayerIDFromULID(ulid.Make())
+		otherID := models.PlayerIDFromULID(ulid.Make())
+		ctx := middleware.ContextWithPlayerID(context.Background(), contextID)
+
+		_, err := s.guardPlayerIDMatchesSelf(ctx, otherID.String())
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("errors on invalid ULID string", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		_, err := s.guardPlayerIDMatchesSelf(ctx, "not-a-ulid")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("errors when context has no player ID", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		someID := models.PlayerIDFromULID(ulid.Make())
+
+		_, err := s.guardPlayerIDMatchesSelf(context.Background(), someID.String())
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+}
+
+func TestGuardRegisteredForEvent(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	eventID := models.EventIDFromULID(ulid.Make())
+	eventKey := "test-event-2026"
+
+	t.Run("returns event ID when registered", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{true, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		got, err := s.guardRegisteredForEvent(ctx, playerID, eventKey)
+		require.NoError(t, err)
+		assert.Equal(t, eventID, got)
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors on unknown event key", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{models.EventID{}, sql.ErrNoRows}}.Bind(mockDAO, "EventIDByKey")
+
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		_, err := s.guardRegisteredForEvent(ctx, playerID, eventKey)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors on EventIDByKey DB error", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{models.EventID{}, errTestDB}}.Bind(mockDAO, "EventIDByKey")
+
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		_, err := s.guardRegisteredForEvent(ctx, playerID, eventKey)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors when not registered", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{false, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		_, err := s.guardRegisteredForEvent(ctx, playerID, eventKey)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors on PlayerRegisteredForEvent DB error", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{false, errTestDB}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+
+		ctx := middleware.ContextWithPlayerID(context.Background(), playerID)
+
+		_, err := s.guardRegisteredForEvent(ctx, playerID, eventKey)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+}
+
+func TestGuardPlayerCategory(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	eventID := models.EventIDFromULID(ulid.Make())
+
+	t.Run("returns category when found", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{models.ScoringCategoryPubGolfNineHole, nil}}.Bind(mockDAO, "PlayerCategoryForEvent")
+
+		got, err := s.guardPlayerCategory(context.Background(), playerID, eventID)
+		require.NoError(t, err)
+		assert.Equal(t, models.ScoringCategoryPubGolfNineHole, got)
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors when not found", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{models.ScoringCategoryUnspecified, sql.ErrNoRows}}.Bind(mockDAO, "PlayerCategoryForEvent")
+
+		_, err := s.guardPlayerCategory(context.Background(), playerID, eventID)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors on DB error", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{models.ScoringCategoryUnspecified, errTestDB}}.Bind(mockDAO, "PlayerCategoryForEvent")
+
+		_, err := s.guardPlayerCategory(context.Background(), playerID, eventID)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+}
+
+func TestGuardValidCategory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns model for valid enum", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		got, err := s.guardValidCategory(context.Background(), apiv1.ScoringCategory_SCORING_CATEGORY_PUB_GOLF_NINE_HOLE)
+		require.NoError(t, err)
+		assert.Equal(t, models.ScoringCategoryPubGolfNineHole, got)
+	})
+
+	t.Run("errors on invalid enum", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		_, err := s.guardValidCategory(context.Background(), apiv1.ScoringCategory(9999))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+}
+
+func TestGuardStageID(t *testing.T) {
+	t.Parallel()
+
+	eventID := models.EventIDFromULID(ulid.Make())
+	stageID := models.StageIDFromULID(ulid.Make())
+	vk := models.VenueKeyFromUInt32(1)
+
+	t.Run("returns stage ID when found", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, vk}, Return: []any{stageID, nil}}.Bind(mockDAO, "StageIDByVenueKey")
+
+		got, err := s.guardStageID(context.Background(), eventID, vk)
+		require.NoError(t, err)
+		assert.Equal(t, stageID, got)
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors when not found", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, vk}, Return: []any{models.StageID{}, sql.ErrNoRows}}.Bind(mockDAO, "StageIDByVenueKey")
+
+		_, err := s.guardStageID(context.Background(), eventID, vk)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+
+	t.Run("errors on DB error", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, vk}, Return: []any{models.StageID{}, errTestDB}}.Bind(mockDAO, "StageIDByVenueKey")
+
+		_, err := s.guardStageID(context.Background(), eventID, vk)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+		mockDAO.AssertExpectations(t)
+	})
+}

--- a/api/internal/lib/rpc/public/start_player_login_test.go
+++ b/api/internal/lib/rpc/public/start_player_login_test.go
@@ -1,0 +1,90 @@
+package public
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+	"github.com/pubgolf/pubgolf/api/internal/lib/sms"
+)
+
+func TestStartPlayerLogin(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	phoneNum := models.PhoneNum("+15551234567")
+
+	t.Run("New player", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, "", phoneNum}, Return: []any{models.Player{ID: playerID}, nil}}.Bind(mockDAO, "CreatePlayer")
+		mockMes.On("SendVerification", mock.Anything, phoneNum).Return(nil)
+
+		_, err := s.StartPlayerLogin(t.Context(), connect.NewRequest(&apiv1.StartPlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+		}))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Existing player", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, "", phoneNum}, Return: []any{models.Player{}, dao.ErrAlreadyCreated}}.Bind(mockDAO, "CreatePlayer")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, phoneNum}, Return: []any{false, nil}}.Bind(mockDAO, "PhoneNumberIsVerified")
+		mockMes.On("SendVerification", mock.Anything, phoneNum).Return(nil)
+
+		_, err := s.StartPlayerLogin(t.Context(), connect.NewRequest(&apiv1.StartPlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+		}))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Invalid phone number", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		_, err := s.StartPlayerLogin(t.Context(), connect.NewRequest(&apiv1.StartPlayerLoginRequest{
+			PhoneNumber: "invalid",
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("SMS send failure", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		mockMes := new(sms.MockMessenger)
+		s := NewServer(mockDAO, mockMes)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, "", phoneNum}, Return: []any{models.Player{ID: playerID}, nil}}.Bind(mockDAO, "CreatePlayer")
+		mockMes.On("SendVerification", mock.Anything, phoneNum).Return(sms.ErrUpstreamProviderIssue)
+
+		_, err := s.StartPlayerLogin(t.Context(), connect.NewRequest(&apiv1.StartPlayerLoginRequest{
+			PhoneNumber: "+15551234567",
+		}))
+
+		require.Error(t, err)
+	})
+}

--- a/api/internal/lib/rpc/public/submit_score_test.go
+++ b/api/internal/lib/rpc/public/submit_score_test.go
@@ -1,0 +1,194 @@
+package public
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/forms"
+	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestSubmitScore(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	gameCtx := middleware.ContextWithPlayerID(t.Context(), playerID)
+	eventKey := "test-event"
+	eventID := models.EventIDFromULID(ulid.Make())
+	stageID := models.StageIDFromULID(ulid.Make())
+	adjTemplateID := models.AdjustmentTemplateIDFromULID(ulid.Make())
+
+	mockGuards := func(mockDAO *dao.MockQueryProvider) {
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{true, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventID, models.VenueKeyFromUInt32(1)}, Return: []any{stageID, nil}}.Bind(mockDAO, "StageIDByVenueKey")
+	}
+
+	validFormData := &apiv1.FormSubmission{
+		Values: []*apiv1.FormValue{
+			{
+				Id: forms.SubmitScoreInputIDSips,
+				Value: &apiv1.FormValue_Numeric{
+					Numeric: 3,
+				},
+			},
+		},
+	}
+
+	t.Run("Valid score, no adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockGuards(mockDAO)
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, stageID}, Return: []any{[]models.AdjustmentTemplate(nil), nil}}.Bind(mockDAO, "AdjustmentTemplatesByStageID")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything}, Return: []any{nil}}.Bind(mockDAO, "UpsertScore")
+
+		resp, err := s.SubmitScore(gameCtx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+			Data:     validFormData,
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ScoreStatus_SCORE_STATUS_SUBMITTED_EDITABLE, resp.Msg.GetStatus())
+	})
+
+	t.Run("Valid score with adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockGuards(mockDAO)
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, stageID}, Return: []any{[]models.AdjustmentTemplate{
+			{ID: adjTemplateID, Label: "Bonus", Value: -1, VenueSpecific: false},
+		}, nil}}.Bind(mockDAO, "AdjustmentTemplatesByStageID")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything}, Return: []any{nil}}.Bind(mockDAO, "UpsertScore")
+
+		resp, err := s.SubmitScore(gameCtx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+			Data: &apiv1.FormSubmission{
+				Values: []*apiv1.FormValue{
+					{
+						Id: forms.SubmitScoreInputIDSips,
+						Value: &apiv1.FormValue_Numeric{
+							Numeric: 3,
+						},
+					},
+					{
+						Id: forms.SubmitScoreInputIDStandardAdj,
+						Value: &apiv1.FormValue_SelectMany{
+							SelectMany: &apiv1.SelectManyValue{
+								SelectedIds: []string{adjTemplateID.String()},
+							},
+						},
+					},
+				},
+			},
+		}))
+
+		require.NoError(t, err)
+		assert.Equal(t, apiv1.ScoreStatus_SCORE_STATUS_SUBMITTED_EDITABLE, resp.Msg.GetStatus())
+	})
+
+	t.Run("Invalid form data (score=0)", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockGuards(mockDAO)
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, stageID}, Return: []any{[]models.AdjustmentTemplate(nil), nil}}.Bind(mockDAO, "AdjustmentTemplatesByStageID")
+
+		_, err := s.SubmitScore(gameCtx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+			Data: &apiv1.FormSubmission{
+				Values: []*apiv1.FormValue{
+					{
+						Id: forms.SubmitScoreInputIDSips,
+						Value: &apiv1.FormValue_Numeric{
+							Numeric: 0,
+						},
+					},
+				},
+			},
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("Unknown adjustment ID", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		mockGuards(mockDAO)
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, stageID}, Return: []any{[]models.AdjustmentTemplate(nil), nil}}.Bind(mockDAO, "AdjustmentTemplatesByStageID")
+
+		unknownAdjID := models.AdjustmentTemplateIDFromULID(ulid.Make())
+
+		_, err := s.SubmitScore(gameCtx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+			Data: &apiv1.FormSubmission{
+				Values: []*apiv1.FormValue{
+					{
+						Id: forms.SubmitScoreInputIDSips,
+						Value: &apiv1.FormValue_Numeric{
+							Numeric: 3,
+						},
+					},
+					{
+						Id: forms.SubmitScoreInputIDStandardAdj,
+						Value: &apiv1.FormValue_SelectMany{
+							SelectMany: &apiv1.SelectManyValue{
+								SelectedIds: []string{unknownAdjID.String()},
+							},
+						},
+					},
+				},
+			},
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("Not registered for event", func(t *testing.T) {
+		t.Parallel()
+
+		mockDAO := new(dao.MockQueryProvider)
+		s := makeTestServer(mockDAO)
+
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, eventKey}, Return: []any{eventID, nil}}.Bind(mockDAO, "EventIDByKey")
+		dao.MockDAOCall{ShouldCall: true, Args: []any{mock.Anything, playerID, eventID}, Return: []any{false, nil}}.Bind(mockDAO, "PlayerRegisteredForEvent")
+
+		_, err := s.SubmitScore(gameCtx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			PlayerId: playerID.String(),
+			EventKey: eventKey,
+			VenueKey: 1,
+			Data:     validFormData,
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}


### PR DESCRIPTION
## Summary
- **Guards** (Phase 4): Tests for all 6 guard functions (`guardInferredPlayerID`, `guardPlayerIDMatchesSelf`, `guardRegisteredForEvent`, `guardPlayerCategory`, `guardValidCategory`, `guardStageID`) + `ClientVersion` handler
- **Handlers** (Phase 5): Tests for `SubmitScore`, `GetSubmitScoreForm`, `GetScoresForCategory`, `CompletePlayerLogin`, `StartPlayerLogin`
- **Test infrastructure**: Adds async mock result constructors to `testhelpers.go` (`MockScoringCriteriaAsyncResult`, `MockEventStartTimeAsyncResult`, `MockEventScheduleAsyncResult`, `MockAdjustmentTemplatesByStageIDAsyncResult`, `MockScoreByPlayerStageAsyncResult`)

## Test plan
- [x] `go test ./api/internal/lib/rpc/public/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)