### PR TITLE
add(api): worktree-agnostic tests + DB connection stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 data/
+.worktrees/

--- a/api/cmd/pubgolf-api-server/http_handlers.go
+++ b/api/cmd/pubgolf-api-server/http_handlers.go
@@ -1,11 +1,45 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/pubgolf/pubgolf/api/internal/lib/config"
 )
+
+// status reports DB reachability and live pool stats for dashboards and debugging.
+// This is NOT a liveness probe — do not wire it to any deploy health check signal.
+func status(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+
+		dbStatus := "ok"
+		code := http.StatusOK
+
+		pingErr := db.PingContext(ctx)
+		if pingErr != nil {
+			dbStatus = pingErr.Error()
+			code = http.StatusServiceUnavailable
+		}
+
+		stats := db.Stats()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		fmt.Fprintf(w,
+			`{"db":%q,"pool":{"open":%d,"in_use":%d,"idle":%d,"wait_count":%d}}`,
+			dbStatus,
+			stats.OpenConnections,
+			stats.InUse,
+			stats.Idle,
+			stats.WaitCount,
+		)
+	}
+}
 
 // healthCheck returns a 200 if the app is online and able to process requests.
 func healthCheck(cfg *config.App) http.HandlerFunc {

--- a/api/cmd/pubgolf-api-server/main.go
+++ b/api/cmd/pubgolf-api-server/main.go
@@ -63,6 +63,7 @@ func main() {
 
 	// Initialize DB.
 	dbConn := makeDB(ctx, cfg)
+	defer dbConn.Close()
 
 	// Run migrations and exit if migrator instance.
 	if *migrationFlag {
@@ -84,11 +85,18 @@ func main() {
 
 	// Initialize server.
 
-	dao, err := dao.New(ctx, dbConn, cfg.EnvName == config.DeployEnvDev || cfg.EnvName == config.DeployEnvE2ETest)
+	daoInstance, err := dao.New(ctx, dbConn, cfg.EnvName == config.DeployEnvDev || cfg.EnvName == config.DeployEnvE2ETest)
 	guard(err, "init DAO")
 
+	defer func() {
+		closeErr := daoInstance.Close()
+		if closeErr != nil {
+			log.Printf("DAO close error: %v", closeErr)
+		}
+	}()
+
 	mes := sms.New(cfg.Twilio, cfg.SMSAllowList)
-	server := makeServer(cfg, dao, mes)
+	server := makeServer(cfg, daoInstance, mes, dbConn)
 	makeShutdownWatcher(server)
 
 	// Run server.
@@ -110,28 +118,51 @@ func guard(err error, msg string) {
 	}
 }
 
-// makeDB instantiates a database connection, verifies ability to connect and initializes tracing/debugging tools as necessary.
+// makeDB instantiates a database connection pool with explicit tuning and initializes tracing/debugging tools as necessary.
 func makeDB(ctx context.Context, cfg *config.App) *sql.DB {
-	conConfig, err := pgxpool.New(ctx, cfg.AppDatabaseURL)
+	poolCfg, err := pgxpool.ParseConfig(cfg.AppDatabaseURL)
 	guard(err, "parse database config")
 
-	db := telemetry.WrapDB(stdlib.GetPoolConnector(conConfig))
+	poolCfg.MaxConns = 25 // validate against Postgres max_connections
+	poolCfg.MinConns = 2
+	poolCfg.MaxConnLifetime = 1 * time.Hour
+	poolCfg.MaxConnLifetimeJitter = 10 * time.Minute // spread recycling; prevents thundering herd
+	poolCfg.MaxConnIdleTime = 10 * time.Minute       // set below firewall/LB idle timeout
+	poolCfg.HealthCheckPeriod = 1 * time.Minute
+	poolCfg.ConnConfig.RuntimeParams["statement_timeout"] = "5000" // 5 seconds
 
-	if cfg.EnvName == config.DeployEnvDev || cfg.EnvName == config.DeployEnvE2ETest {
-		err = db.PingContext(ctx)
-		guard(err, "ping database")
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	guard(err, "create connection pool")
+
+	var db *sql.DB
+
+	db = telemetry.WrapDB(stdlib.GetPoolConnector(pool), func() sql.DBStats {
+		return db.Stats()
+	})
+
+	// Align database/sql's own pool layer with pgxpool settings so the two
+	// stacked pools don't compete with each other's eviction policies.
+	db.SetMaxOpenConns(int(poolCfg.MaxConns))
+	db.SetMaxIdleConns(int(poolCfg.MaxConns))
+	db.SetConnMaxLifetime(poolCfg.MaxConnLifetime)
+	db.SetConnMaxIdleTime(poolCfg.MaxConnIdleTime)
+
+	pingErr := db.PingContext(ctx)
+	if pingErr != nil {
+		log.Printf("Warning: DB not reachable at startup: %v — will retry on first request", pingErr)
 	}
 
 	return db
 }
 
 // makeServer initializes an HTTP server with settings and the router.
-func makeServer(cfg *config.App, dao dao.QueryProvider, mes sms.Messenger) *http.Server {
+func makeServer(cfg *config.App, dao dao.QueryProvider, mes sms.Messenger, db *sql.DB) *http.Server {
 	r := chi.NewRouter()
 	r.Use(middleware.ChiMiddleware(r)...)
 
 	// Mount routes.
 	r.Get("/health-check", healthCheck(cfg))
+	r.Get("/status", status(db))
 	r.Get("/robots.txt", robots(cfg))
 	r.Route("/web-api/", webapi.Router(cfg))
 	r.Route("/rpc/", func(r chi.Router) {

--- a/api/internal/lib/dao/dao.go
+++ b/api/internal/lib/dao/dao.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 
 	"github.com/pubgolf/pubgolf/api/internal/lib/dao/internal/dbc"
@@ -45,6 +46,21 @@ func New(ctx context.Context, db *sql.DB, forcePreparedQueries bool) (*Queries, 
 		db:  db,
 		dbc: q,
 	}, nil
+}
+
+// Close releases any prepared statements held by the DAO.
+func (q *Queries) Close() error {
+	closer, ok := q.dbc.(io.Closer)
+	if !ok {
+		return nil
+	}
+
+	closeErr := closer.Close()
+	if closeErr != nil {
+		return fmt.Errorf("close prepared statements: %w", closeErr)
+	}
+
+	return nil
 }
 
 func (q *Queries) useTx(ctx context.Context, query func(ctx context.Context, q *Queries) error) error {

--- a/api/internal/lib/dbtest/dbtest.go
+++ b/api/internal/lib/dbtest/dbtest.go
@@ -124,14 +124,27 @@ func Migrate(conn *sql.DB, migrationDir string) {
 	guardSetup(migrator.Up(), "migrate test DB")
 }
 
-// MigrationDir returns the relative path to the migrations directory. Must be called directly from within the package being tested, since that's what sets the current working directory of the test process.
+// MigrationDir returns the absolute path to the migrations directory.
 func MigrationDir() string {
-	_, filename, _, _ := runtime.Caller(1)
-	testDir := filepath.Dir(filename)
-	parts := strings.Split(testDir, filepath.FromSlash("/pubgolf/api/"))
-	numDirs := strings.Count(parts[1], string(filepath.Separator))
+	_, filename, _, _ := runtime.Caller(0)
 
-	return filepath.FromSlash(strings.Repeat("../", numDirs) + "db/migrations")
+	dir := filepath.Dir(filename)
+
+	for range 20 { // bounded: prevents infinite walk in misconfigured environments
+		_, statErr := os.Stat(filepath.Join(dir, "go.mod"))
+		if statErr == nil {
+			return filepath.Join(dir, "api", "internal", "db", "migrations")
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+
+		dir = parent
+	}
+
+	panic("dbtest.MigrationDir: could not locate repo root (go.mod not found)")
 }
 
 // NewTestTx returns a context, transaction and cleanup function to isolate a test run into a rolled-back transaction.

--- a/api/internal/lib/telemetry/db.go
+++ b/api/internal/lib/telemetry/db.go
@@ -29,10 +29,26 @@ func parseDBCQueryAttributes(_ context.Context, method otelsql.Method, _ string,
 	}
 }
 
-// WrapDB returns an OTel-instrumented DB handle.
-func WrapDB(db driver.Connector) *sql.DB {
+// WrapDB wraps a database connector with OpenTelemetry instrumentation.
+// statsProvider is called on each span to attach live pool stats; pass nil to omit.
+func WrapDB(db driver.Connector, statsProvider func() sql.DBStats) *sql.DB {
 	return otelsql.OpenDB(db,
 		otelsql.WithSpanNameFormatter(parseDBCQueryName),
-		otelsql.WithAttributesGetter(parseDBCQueryAttributes),
+		otelsql.WithAttributesGetter(func(ctx context.Context, method otelsql.Method, query string, args []driver.NamedValue) []attribute.KeyValue {
+			attrs := parseDBCQueryAttributes(ctx, method, query, args)
+
+			if statsProvider != nil {
+				s := statsProvider()
+				attrs = append(attrs,
+					attribute.Int("db.pool.open", s.OpenConnections),
+					attribute.Int("db.pool.in_use", s.InUse),
+					attribute.Int("db.pool.idle", s.Idle),
+					attribute.Int64("db.pool.wait_count", s.WaitCount),
+					attribute.Int64("db.pool.wait_duration_ms", s.WaitDuration.Milliseconds()),
+				)
+			}
+
+			return attrs
+		}),
 	)
 }


### PR DESCRIPTION
## Summary

- **Fix `MigrationDir()` in worktrees**: Replaces hardcoded `/pubgolf/api/` path-split with a `go.mod` walk anchored to `dbtest.go`'s own file location (`runtime.Caller(0)`), returning an absolute path that works in any directory layout including git worktrees.
- **Explicit connection pool tuning**: Replaces `pgxpool.New` with `pgxpool.ParseConfig` + `NewWithConfig` with explicit `MaxConns=25`, `MinConns=2`, idle/lifetime/jitter/health-check settings; mirrors settings onto `database/sql`'s pool layer to prevent competing eviction policies.
- **Server-side `statement_timeout`**: Sets `statement_timeout=5000ms` via `RuntimeParams` so Postgres terminates runaway queries and frees pool connections, rather than relying on client-side context cancellation alone.
- **Non-fatal startup ping**: Startup no longer fails when the DB is unreachable — demoted to a warning log so deployments aren't blocked by transient DB unavailability.
- **`/status` endpoint**: New read-only endpoint returning DB reachability + live pool stats (open, in-use, idle, wait_count). Intentionally not wired to any liveness/readiness probe.
- **Pool stats in OTel spans**: `WrapDB` now accepts an optional `statsProvider` that attaches pool stats as span attributes on every DB operation, enabling connection exhaustion correlation in Honeycomb traces.
- **Graceful shutdown cleanup**: `defer dbConn.Close()` and `defer daoInstance.Close()` (new `dao.Queries.Close()` method) ensure the pool and prepared statements are released after the HTTP server drains.

## Test plan

- [ ] `pubgolf-devctrl check go` — 0 issues
- [ ] `go test ./api/internal/lib/models/... ./api/internal/lib/dao/...` — all pass
- [ ] Manual smoke: start server locally; `GET /health-check` → 200; `GET /status` → `{"db":"ok",...}` with pool counts
- [ ] Manual smoke: stop postgres; `GET /health-check` still 200; `GET /status` → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)