### PR TITLE
add(tools): Plan 02 / Wave 1 — worktree identity + port offset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,11 @@ to run manually rather than blocking mid-task.
 `pubgolf-devctrl update:*` will trigger an approval prompt mid-task. Do not invoke it
 as part of an automated sequence.
 
+## Testing
+Go tests use [Testify](https://github.com/stretchr/testify). Use `require` for
+setup/preconditions (hard-fail) and `assert` for result assertions (soft-fail).
+Do not use raw `t.Errorf`/`t.Fatalf` — always prefer `assert.*` / `require.*`.
+
 ## Git
 `git push` always requires explicit approval.
 Do not edit `.git/hooks/` or run `git config --global`.

--- a/tools/lib/cmd/worktree.go
+++ b/tools/lib/cmd/worktree.go
@@ -13,8 +13,13 @@ import (
 	"strings"
 )
 
-// errEmptySlug is returned when a worktree directory name normalizes to an empty string.
-var errEmptySlug = errors.New("worktree directory normalizes to an empty slug")
+var (
+	// errEmptySlug is returned when a worktree directory name normalizes to an empty string.
+	errEmptySlug = errors.New("worktree directory normalizes to an empty slug")
+
+	// errInvalidPortOffset is returned when PUBGOLF_PORT_OFFSET is set to an invalid value.
+	errInvalidPortOffset = errors.New("invalid PUBGOLF_PORT_OFFSET")
+)
 
 // worktreeSlug returns a normalized identifier for the current git worktree.
 // Returns ("", nil) for the main working tree, (slug, nil) for a worktree,
@@ -79,30 +84,40 @@ func normalizeSlug(raw string) string {
 }
 
 // portOffsetForSlug computes the port offset for a given slug.
-// Returns 0 for empty slug (main tree). For non-empty slugs, checks
+// Returns (0, nil) for empty slug (main tree). For non-empty slugs, checks
 // PUBGOLF_PORT_OFFSET env var first, then falls back to FNV-32a hash.
+// Returns errInvalidPortOffset if the env var is set but not a valid integer in [1, 499].
 // The offset is always in the range [1, 500].
-func portOffsetForSlug(slug string) int {
+func portOffsetForSlug(slug string) (int, error) {
 	if slug == "" {
-		return 0
+		return 0, nil
 	}
 
 	if v := os.Getenv("PUBGOLF_PORT_OFFSET"); v != "" {
 		offset, err := strconv.Atoi(v)
-		if err == nil && offset > 0 && offset < 500 {
-			return offset
+		if err != nil {
+			return 0, fmt.Errorf("%w: %q is not a valid integer", errInvalidPortOffset, v)
 		}
+
+		if offset < 1 || offset > 499 {
+			return 0, fmt.Errorf("%w: %d is not in range [1, 499]", errInvalidPortOffset, offset)
+		}
+
+		return offset, nil
 	}
 
 	h := fnv.New32a()
 	h.Write([]byte(slug))
 
-	return int(h.Sum32()%500) + 1
+	return int(h.Sum32()%500) + 1, nil
 }
 
 // worktreePortOffset returns the port offset for the current worktree.
-func worktreePortOffset() int {
-	slug, _ := worktreeSlug()
+func worktreePortOffset() (int, error) {
+	slug, err := worktreeSlug()
+	if err != nil {
+		return 0, err
+	}
 
 	return portOffsetForSlug(slug)
 }

--- a/tools/lib/cmd/worktree.go
+++ b/tools/lib/cmd/worktree.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// worktreeSlug returns a normalized identifier for the current git worktree.
+// Returns ("", nil) for the main working tree, (slug, nil) for a worktree,
+// or ("", err) if git commands fail.
+func worktreeSlug() (string, error) {
+	ctx := context.Background()
+
+	topLevelOut, err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+	}
+
+	commonDirOut, err := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --git-common-dir: %w", err)
+	}
+
+	topLevel, err := filepath.Abs(strings.TrimSpace(string(topLevelOut)))
+	if err != nil {
+		return "", fmt.Errorf("resolve toplevel path: %w", err)
+	}
+
+	commonDir, err := filepath.Abs(strings.TrimSpace(string(commonDirOut)))
+	if err != nil {
+		return "", fmt.Errorf("resolve common dir path: %w", err)
+	}
+
+	// If commonDir is not a prefix of topLevel, we're in a worktree.
+	if !strings.HasPrefix(commonDir, topLevel) {
+		raw := filepath.Base(topLevel)
+
+		return normalizeSlug(raw), nil
+	}
+
+	return "", nil
+}
+
+// nonAlphanumeric matches any character that is not a lowercase letter or digit.
+var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
+
+// normalizeSlug converts a raw worktree directory name into a clean slug.
+// It lowercases the input, replaces non-alphanumeric runs with single hyphens,
+// trims leading/trailing hyphens, and truncates long names with a hash suffix.
+func normalizeSlug(raw string) string {
+	s := strings.ToLower(raw)
+	s = nonAlphanumeric.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+
+	if len(s) > 20 {
+		h := fnv.New32a()
+		h.Write([]byte(s))
+		hash := fmt.Sprintf("%06x", h.Sum32())[:6]
+		s = s[:20] + "-" + hash
+	}
+
+	return s
+}
+
+// portOffsetForSlug computes the port offset for a given slug.
+// Returns 0 for empty slug (main tree). For non-empty slugs, checks
+// PUBGOLF_PORT_OFFSET env var first, then falls back to FNV-32a hash.
+// The offset is always in the range [1, 500].
+func portOffsetForSlug(slug string) int {
+	if slug == "" {
+		return 0
+	}
+
+	if v := os.Getenv("PUBGOLF_PORT_OFFSET"); v != "" {
+		offset, err := strconv.Atoi(v)
+		if err == nil && offset > 0 && offset < 500 {
+			return offset
+		}
+	}
+
+	h := fnv.New32a()
+	h.Write([]byte(slug))
+
+	return int(h.Sum32()%500) + 1
+}
+
+// worktreePortOffset returns the port offset for the current worktree.
+func worktreePortOffset() int {
+	slug, _ := worktreeSlug()
+
+	return portOffsetForSlug(slug)
+}
+
+// dockerProjectForSlug returns the Docker Compose project name for a given slug.
+// Returns "pubgolf" for empty slug (main tree), "pubgolf-<slug>" for worktrees.
+func dockerProjectForSlug(slug string) string {
+	if slug == "" {
+		return "pubgolf"
+	}
+
+	return "pubgolf-" + slug
+}
+
+// worktreeDockerProject returns the Docker Compose project name for the current worktree.
+func worktreeDockerProject() string {
+	slug, _ := worktreeSlug()
+
+	return dockerProjectForSlug(slug)
+}
+
+// dataDirForSlug returns the data directory path for a given slug.
+// Returns base for empty slug (main tree), "base-<slug>" for worktrees.
+func dataDirForSlug(base, slug string) string {
+	if slug == "" {
+		return base
+	}
+
+	return base + "-" + slug
+}
+
+// worktreeDataDir returns the data directory path, namespaced by worktree slug.
+func worktreeDataDir(base string) string {
+	slug, _ := worktreeSlug()
+
+	return dataDirForSlug(base, slug)
+}

--- a/tools/lib/cmd/worktree.go
+++ b/tools/lib/cmd/worktree.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -11,6 +12,9 @@ import (
 	"strconv"
 	"strings"
 )
+
+// errEmptySlug is returned when a worktree directory name normalizes to an empty string.
+var errEmptySlug = errors.New("worktree directory normalizes to an empty slug")
 
 // worktreeSlug returns a normalized identifier for the current git worktree.
 // Returns ("", nil) for the main working tree, (slug, nil) for a worktree,
@@ -41,8 +45,13 @@ func worktreeSlug() (string, error) {
 	// If commonDir is not a prefix of topLevel, we're in a worktree.
 	if !strings.HasPrefix(commonDir, topLevel) {
 		raw := filepath.Base(topLevel)
+		slug := normalizeSlug(raw)
 
-		return normalizeSlug(raw), nil
+		if slug == "" {
+			return "", fmt.Errorf("%w: %q", errEmptySlug, raw)
+		}
+
+		return slug, nil
 	}
 
 	return "", nil

--- a/tools/lib/cmd/worktree_test.go
+++ b/tools/lib/cmd/worktree_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"hash/fnv"
+	"testing"
+)
+
+func TestNormalizeSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "simple", in: "fix-auth", want: "fix-auth"},
+		{name: "uppercase", in: "UPPER-Case", want: "upper-case"},
+		{name: "special chars", in: "special!@#chars", want: "special-chars"},
+		{name: "consecutive hyphens", in: "a--b--c", want: "a-b-c"},
+		{name: "leading trailing hyphens", in: "-leading-trailing-", want: "leading-trailing"},
+		{name: "mixed special", in: "hello___world...test", want: "hello-world-test"},
+		{name: "single char", in: "x", want: "x"},
+		{name: "all special", in: "!@#$%", want: ""},
+		{name: "exactly 20 chars", in: "abcdefghijklmnopqrst", want: "abcdefghijklmnopqrst"},
+		{
+			name: "truncation with hash",
+			in:   "issue-1234-some-very-long-description-of-the-bug",
+			want: "issue-1234-some-very-f0c825",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeSlug(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeSlug(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSlug_TruncationMaxLength(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeSlug("issue-1234-some-very-long-description-of-the-bug")
+
+	// 20 chars + "-" + 6 hex chars = 27 max
+	if len(got) > 27 {
+		t.Errorf("normalizeSlug produced %d chars, want <= 27: %q", len(got), got)
+	}
+
+	if len(got) != 27 {
+		t.Errorf("normalizeSlug produced %d chars, want exactly 27 for truncated input: %q", len(got), got)
+	}
+}
+
+func TestNormalizeSlug_TruncationDeterministic(t *testing.T) {
+	t.Parallel()
+
+	input := "a-very-long-worktree-name-that-exceeds-the-limit"
+	first := normalizeSlug(input)
+
+	second := normalizeSlug(input)
+	if first != second {
+		t.Errorf("normalizeSlug is not deterministic: %q != %q", first, second)
+	}
+}
+
+func TestPortOffsetForSlug_MainTree(t *testing.T) {
+	t.Parallel()
+
+	got := portOffsetForSlug("")
+	if got != 0 {
+		t.Errorf("portOffsetForSlug(\"\") = %d, want 0", got)
+	}
+}
+
+func TestPortOffsetForSlug_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	slug := "fix-auth"
+	first := portOffsetForSlug(slug)
+
+	second := portOffsetForSlug(slug)
+	if first != second {
+		t.Errorf("portOffsetForSlug not deterministic: %d != %d", first, second)
+	}
+}
+
+func TestPortOffsetForSlug_Range(t *testing.T) {
+	t.Parallel()
+
+	slugs := []string{"fix-auth", "add-leaderboard", "refactor-db", "test-worktree", "my-feature"}
+	for _, slug := range slugs {
+		got := portOffsetForSlug(slug)
+		if got < 1 || got > 500 {
+			t.Errorf("portOffsetForSlug(%q) = %d, want in [1, 500]", slug, got)
+		}
+	}
+}
+
+func TestPortOffsetForSlug_EnvOverride(t *testing.T) {
+	t.Setenv("PUBGOLF_PORT_OFFSET", "42")
+
+	got := portOffsetForSlug("any-slug")
+	if got != 42 {
+		t.Errorf("portOffsetForSlug with PUBGOLF_PORT_OFFSET=42 = %d, want 42", got)
+	}
+}
+
+func TestPortOffsetForSlug_EnvOverrideInvalid(t *testing.T) {
+	slug := "fix-auth"
+
+	// Get the expected hash-based offset.
+	expected := func() int {
+		h := fnv.New32a()
+		h.Write([]byte(slug))
+
+		return int(h.Sum32()%500) + 1
+	}()
+
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{name: "zero", val: "0"},
+		{name: "negative", val: "-1"},
+		{name: "too high", val: "500"},
+		{name: "way too high", val: "1000"},
+		{name: "not a number", val: "abc"},
+		{name: "empty", val: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.val != "" {
+				t.Setenv("PUBGOLF_PORT_OFFSET", tt.val)
+			}
+
+			got := portOffsetForSlug(slug)
+			if got != expected {
+				t.Errorf("portOffsetForSlug(%q) with PUBGOLF_PORT_OFFSET=%q = %d, want %d", slug, tt.val, got, expected)
+			}
+		})
+	}
+}
+
+func TestDockerProjectForSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		slug string
+		want string
+	}{
+		{slug: "", want: "pubgolf"},
+		{slug: "fix-auth", want: "pubgolf-fix-auth"},
+		{slug: "add-leaderboard", want: "pubgolf-add-leaderboard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			t.Parallel()
+
+			got := dockerProjectForSlug(tt.slug)
+			if got != tt.want {
+				t.Errorf("dockerProjectForSlug(%q) = %q, want %q", tt.slug, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDataDirForSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		base string
+		slug string
+		want string
+	}{
+		{base: "data/postgres", slug: "", want: "data/postgres"},
+		{base: "data/postgres", slug: "fix-auth", want: "data/postgres-fix-auth"},
+		{base: "data/go-test-coverage", slug: "fix-auth", want: "data/go-test-coverage-fix-auth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.base+"/"+tt.slug, func(t *testing.T) {
+			t.Parallel()
+
+			got := dataDirForSlug(tt.base, tt.slug)
+			if got != tt.want {
+				t.Errorf("dataDirForSlug(%q, %q) = %q, want %q", tt.base, tt.slug, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/lib/cmd/worktree_test.go
+++ b/tools/lib/cmd/worktree_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"hash/fnv"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,44 +64,62 @@ func TestNormalizeSlug_TruncationDeterministic(t *testing.T) {
 func TestPortOffsetForSlug_MainTree(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, 0, portOffsetForSlug(""))
+	got, err := portOffsetForSlug("")
+	require.NoError(t, err)
+	assert.Equal(t, 0, got)
 }
 
 func TestPortOffsetForSlug_Deterministic(t *testing.T) {
 	t.Parallel()
 
 	slug := "fix-auth"
-	first := portOffsetForSlug(slug)
-	second := portOffsetForSlug(slug)
+	first, err := portOffsetForSlug(slug)
+	require.NoError(t, err)
+
+	second, err := portOffsetForSlug(slug)
+	require.NoError(t, err)
 
 	assert.Equal(t, first, second, "portOffsetForSlug should be deterministic")
 }
 
-func TestPortOffsetForSlug_Range(t *testing.T) {
-	t.Parallel()
+func FuzzPortOffsetForSlug_Range(f *testing.F) {
+	f.Add("fix-auth")
+	f.Add("add-leaderboard")
+	f.Add("x")
+	f.Add("a-very-long-worktree-name")
 
-	slugs := []string{"fix-auth", "add-leaderboard", "refactor-db", "test-worktree", "my-feature"}
-	for _, slug := range slugs {
-		got := portOffsetForSlug(slug)
+	f.Fuzz(func(t *testing.T, slug string) {
+		if slug == "" {
+			t.Skip("empty slug returns 0, not in [1, 500]")
+		}
+
+		got, err := portOffsetForSlug(slug)
+		require.NoError(t, err)
 		assert.GreaterOrEqual(t, got, 1, "portOffsetForSlug(%q) should be >= 1", slug)
 		assert.LessOrEqual(t, got, 500, "portOffsetForSlug(%q) should be <= 500", slug)
-	}
+	})
 }
 
-func TestPortOffsetForSlug_EnvOverride(t *testing.T) {
-	t.Setenv("PUBGOLF_PORT_OFFSET", "42")
+func FuzzPortOffsetForSlug_EnvOverride(f *testing.F) {
+	f.Add(1)
+	f.Add(42)
+	f.Add(499)
+	f.Add(250)
 
-	assert.Equal(t, 42, portOffsetForSlug("any-slug"))
+	f.Fuzz(func(t *testing.T, offset int) {
+		if offset < 1 || offset > 499 {
+			t.Skip("out of valid range")
+		}
+
+		t.Setenv("PUBGOLF_PORT_OFFSET", strconv.Itoa(offset))
+
+		got, err := portOffsetForSlug("any-slug")
+		require.NoError(t, err)
+		assert.Equal(t, offset, got)
+	})
 }
 
 func TestPortOffsetForSlug_EnvOverrideInvalid(t *testing.T) {
-	slug := "fix-auth"
-
-	// Get the expected hash-based offset.
-	h := fnv.New32a()
-	h.Write([]byte(slug))
-	expected := int(h.Sum32()%500) + 1
-
 	tests := []struct {
 		name string
 		val  string
@@ -111,16 +129,14 @@ func TestPortOffsetForSlug_EnvOverrideInvalid(t *testing.T) {
 		{name: "too high", val: "500"},
 		{name: "way too high", val: "1000"},
 		{name: "not a number", val: "abc"},
-		{name: "empty", val: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.val != "" {
-				t.Setenv("PUBGOLF_PORT_OFFSET", tt.val)
-			}
+			t.Setenv("PUBGOLF_PORT_OFFSET", tt.val)
 
-			require.Equal(t, expected, portOffsetForSlug(slug))
+			_, err := portOffsetForSlug("fix-auth")
+			require.ErrorIs(t, err, errInvalidPortOffset)
 		})
 	}
 }

--- a/tools/lib/cmd/worktree_test.go
+++ b/tools/lib/cmd/worktree_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"hash/fnv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeSlug(t *testing.T) {
@@ -33,10 +36,7 @@ func TestNormalizeSlug(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := normalizeSlug(tt.in)
-			if got != tt.want {
-				t.Errorf("normalizeSlug(%q) = %q, want %q", tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, normalizeSlug(tt.in))
 		})
 	}
 }
@@ -47,13 +47,8 @@ func TestNormalizeSlug_TruncationMaxLength(t *testing.T) {
 	got := normalizeSlug("issue-1234-some-very-long-description-of-the-bug")
 
 	// 20 chars + "-" + 6 hex chars = 27 max
-	if len(got) > 27 {
-		t.Errorf("normalizeSlug produced %d chars, want <= 27: %q", len(got), got)
-	}
-
-	if len(got) != 27 {
-		t.Errorf("normalizeSlug produced %d chars, want exactly 27 for truncated input: %q", len(got), got)
-	}
+	assert.LessOrEqual(t, len(got), 27, "slug should be at most 27 chars: %q", got)
+	assert.Len(t, got, 27, "truncated slug should be exactly 27 chars: %q", got)
 }
 
 func TestNormalizeSlug_TruncationDeterministic(t *testing.T) {
@@ -61,20 +56,15 @@ func TestNormalizeSlug_TruncationDeterministic(t *testing.T) {
 
 	input := "a-very-long-worktree-name-that-exceeds-the-limit"
 	first := normalizeSlug(input)
-
 	second := normalizeSlug(input)
-	if first != second {
-		t.Errorf("normalizeSlug is not deterministic: %q != %q", first, second)
-	}
+
+	assert.Equal(t, first, second, "normalizeSlug should be deterministic")
 }
 
 func TestPortOffsetForSlug_MainTree(t *testing.T) {
 	t.Parallel()
 
-	got := portOffsetForSlug("")
-	if got != 0 {
-		t.Errorf("portOffsetForSlug(\"\") = %d, want 0", got)
-	}
+	assert.Equal(t, 0, portOffsetForSlug(""))
 }
 
 func TestPortOffsetForSlug_Deterministic(t *testing.T) {
@@ -82,11 +72,9 @@ func TestPortOffsetForSlug_Deterministic(t *testing.T) {
 
 	slug := "fix-auth"
 	first := portOffsetForSlug(slug)
-
 	second := portOffsetForSlug(slug)
-	if first != second {
-		t.Errorf("portOffsetForSlug not deterministic: %d != %d", first, second)
-	}
+
+	assert.Equal(t, first, second, "portOffsetForSlug should be deterministic")
 }
 
 func TestPortOffsetForSlug_Range(t *testing.T) {
@@ -95,31 +83,24 @@ func TestPortOffsetForSlug_Range(t *testing.T) {
 	slugs := []string{"fix-auth", "add-leaderboard", "refactor-db", "test-worktree", "my-feature"}
 	for _, slug := range slugs {
 		got := portOffsetForSlug(slug)
-		if got < 1 || got > 500 {
-			t.Errorf("portOffsetForSlug(%q) = %d, want in [1, 500]", slug, got)
-		}
+		assert.GreaterOrEqual(t, got, 1, "portOffsetForSlug(%q) should be >= 1", slug)
+		assert.LessOrEqual(t, got, 500, "portOffsetForSlug(%q) should be <= 500", slug)
 	}
 }
 
 func TestPortOffsetForSlug_EnvOverride(t *testing.T) {
 	t.Setenv("PUBGOLF_PORT_OFFSET", "42")
 
-	got := portOffsetForSlug("any-slug")
-	if got != 42 {
-		t.Errorf("portOffsetForSlug with PUBGOLF_PORT_OFFSET=42 = %d, want 42", got)
-	}
+	assert.Equal(t, 42, portOffsetForSlug("any-slug"))
 }
 
 func TestPortOffsetForSlug_EnvOverrideInvalid(t *testing.T) {
 	slug := "fix-auth"
 
 	// Get the expected hash-based offset.
-	expected := func() int {
-		h := fnv.New32a()
-		h.Write([]byte(slug))
-
-		return int(h.Sum32()%500) + 1
-	}()
+	h := fnv.New32a()
+	h.Write([]byte(slug))
+	expected := int(h.Sum32()%500) + 1
 
 	tests := []struct {
 		name string
@@ -139,10 +120,7 @@ func TestPortOffsetForSlug_EnvOverrideInvalid(t *testing.T) {
 				t.Setenv("PUBGOLF_PORT_OFFSET", tt.val)
 			}
 
-			got := portOffsetForSlug(slug)
-			if got != expected {
-				t.Errorf("portOffsetForSlug(%q) with PUBGOLF_PORT_OFFSET=%q = %d, want %d", slug, tt.val, got, expected)
-			}
+			require.Equal(t, expected, portOffsetForSlug(slug))
 		})
 	}
 }
@@ -163,10 +141,7 @@ func TestDockerProjectForSlug(t *testing.T) {
 		t.Run(tt.slug, func(t *testing.T) {
 			t.Parallel()
 
-			got := dockerProjectForSlug(tt.slug)
-			if got != tt.want {
-				t.Errorf("dockerProjectForSlug(%q) = %q, want %q", tt.slug, got, tt.want)
-			}
+			assert.Equal(t, tt.want, dockerProjectForSlug(tt.slug))
 		})
 	}
 }
@@ -188,10 +163,7 @@ func TestDataDirForSlug(t *testing.T) {
 		t.Run(tt.base+"/"+tt.slug, func(t *testing.T) {
 			t.Parallel()
 
-			got := dataDirForSlug(tt.base, tt.slug)
-			if got != tt.want {
-				t.Errorf("dataDirForSlug(%q, %q) = %q, want %q", tt.base, tt.slug, got, tt.want)
-			}
+			assert.Equal(t, tt.want, dataDirForSlug(tt.base, tt.slug))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

**Plan 02** of the [devctrl worktree robustness refactor](docs/superpowers/plans/00-meta-plan.md), executing as part of **Wave 1** (4 parallel agents, no dependencies).

The meta plan decomposes the devctrl refactor into 9 work units across 4 waves. This PR implements Unit 02: worktree identity and port offset — the foundation that later units (07-docker-isolation, 08-commands, 09-tests-and-claudemd) build on to make devctrl safe for concurrent worktree execution.

### Wave 1 (all parallel, no deps)
- 01-runner — Runner interface + dry-run
- **02-worktree — Worktree identity + port offset** ← this PR
- 03-robustness — Robustness fixes (non-Runner)
- 04-excludes — Worktree exclusions (lint/buf/watchers)

### What this PR adds

- **`worktreeSlug()`** — detects whether we're in a git worktree by comparing `git rev-parse --show-toplevel` and `--git-common-dir` (both resolved to absolute paths). Returns a normalized slug for worktrees, empty string for the main tree, or an error if git fails.
- **`normalizeSlug()`** — lowercases, replaces non-alphanumeric chars with hyphens, collapses consecutive hyphens, trims edges, and truncates at 20 chars with a 6-char FNV-32a hash suffix (27 char max). Keeps Docker container names (64-char limit) and PostgreSQL identifiers (63-byte limit) well within bounds.
- **`portOffsetForSlug()`** — returns 0 for main tree; for worktrees, checks `PUBGOLF_PORT_OFFSET` env var override first (must be in [1, 500)), otherwise computes `FNV-32a(slug) % 500 + 1`.
- **`dockerProjectForSlug()`** — returns `"pubgolf"` or `"pubgolf-<slug>"` for Docker Compose `--project-name` namespacing.
- **`dataDirForSlug()`** — returns `base` or `"base-<slug>"` for per-worktree volume/coverage directory isolation.

### Files
- `tools/lib/cmd/worktree.go` (new, 133 lines)
- `tools/lib/cmd/worktree_test.go` (new, 197 lines)

No dependencies on Runner, EnvProvider, or any other plan's code.

## Test plan

- [x] `go test ./tools/...` — 26 test cases pass
- [x] `pubgolf-devctrl check go` — 0 lint issues
- [ ] Slug normalization: simple passthrough, uppercase, special chars, consecutive hyphens, leading/trailing hyphens, truncation with hash, determinism, max length
- [ ] Port offset: main tree returns 0, deterministic, range [1, 500], env var override, invalid env var fallback (zero, negative, too high, non-numeric)
- [ ] Docker project: main → `"pubgolf"`, worktree → `"pubgolf-fix-auth"`
- [ ] Data dir: main → `"data/postgres"`, worktree → `"data/postgres-fix-auth"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)