### PR TITLE
Wave 1, Plan 04: Exclude .worktrees/ from lint, buf, and file watchers

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,8 +1,6 @@
 version: v2
 modules:
   - path: proto
-    excludes:
-      - .worktrees
     lint:
       disallow_comment_ignores: true
     breaking:

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,8 @@
 version: v2
 modules:
   - path: proto
+    excludes:
+      - .worktrees
     lint:
       disallow_comment_ignores: true
     breaking:

--- a/tools/lib/cmd/check.go
+++ b/tools/lib/cmd/check.go
@@ -33,7 +33,7 @@ var checkGoCmd = &cobra.Command{
 }
 
 func checkGo(ctx context.Context) error {
-	lint := exec.CommandContext(ctx, "golangci-lint", "run", "./api/...", "./tools/...")
+	lint := exec.CommandContext(ctx, "golangci-lint", "run", "--exclude-dirs", `\.worktrees`, "./api/...", "./tools/...")
 	lint.Stdout = os.Stdout
 	lint.Stderr = os.Stderr
 

--- a/tools/lib/cmd/root.go
+++ b/tools/lib/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -106,10 +107,29 @@ func runPar(cmd *cobra.Command, args []string, commands ...*cobra.Command) {
 	wg.Wait()
 }
 
+// ignoredDirPatterns lists directory names that file watchers should skip.
+var ignoredDirPatterns = []string{
+	".worktrees",
+	"node_modules",
+	"vendor",
+	"data",
+	".git",
+}
+
 // watch sets up a recursive file watcher to re-run tasks.
 func watch(dir, label string, callback func(watcher.Event)) {
 	w := watcher.New()
 	w.SetMaxEvents(1)
+	w.AddFilterHook(func(_ os.FileInfo, fullPath string) error {
+		for _, pattern := range ignoredDirPatterns {
+			if strings.Contains(fullPath, string(os.PathSeparator)+pattern+string(os.PathSeparator)) ||
+				strings.HasSuffix(fullPath, string(os.PathSeparator)+pattern) {
+				return watcher.ErrSkip
+			}
+		}
+
+		return nil
+	})
 
 	go func() {
 		for {


### PR DESCRIPTION
## Summary

Part of the **devctrl worktree robustness refactor** — Wave 1, Plan 04 (no dependencies).
Orchestrated via `docs/superpowers/plans/run-devctrl-agents.sh`.

Prevents linting, buf, and file watchers on main from picking up files inside `.worktrees/`, fixing the most immediately-felt bug: **lint failures on main caused by in-flight worktree changes**.

- **golangci-lint**: Add `--exclude-dirs \.worktrees` flag to the `checkGo()` invocation
- **buf.yaml**: Add `.worktrees` to module `excludes` list (affects both `buf lint` and `buf generate`)
- **File watchers**: Add a centralized `ignoredDirPatterns` list and a `FilterFileHookFunc` in `watch()` that skips `.worktrees`, `node_modules`, `vendor`, `data`, and `.git` directories

## Files changed

| File | Change |
|------|--------|
| `tools/lib/cmd/check.go` | Add `--exclude-dirs \.worktrees` to golangci-lint args |
| `buf.yaml` | Add `excludes: [.worktrees]` to module config |
| `tools/lib/cmd/root.go` | Add `ignoredDirPatterns` var and filter hook in `watch()` |

## What to look for in code review

1. **`check.go` — regex pattern**: The `--exclude-dirs` flag takes a regex, so `\.worktrees` escapes the dot. Verify this is the right pattern (vs. a glob or literal string).

2. **`buf.yaml` — excludes placement**: The `excludes` key is at the module level (under `- path: proto`). Buf v2 `excludes` paths are relative to the `buf.yaml` root. Verify this correctly prevents buf from traversing `.worktrees/` — since the module `path` is `proto`, buf may already ignore sibling directories, making this defensive rather than strictly necessary.

3. **`root.go` — filter hook approach**: The watcher library's `Ignore()` method takes absolute paths, which isn't useful for pattern matching. Instead, this uses `AddFilterHook` with path-segment matching (`/pattern/` or suffix `/pattern`). Verify the path separator logic handles edge cases correctly on macOS (the target platform).

4. **`root.go` — extra ignored dirs**: The plan specified ignoring `node_modules`, `vendor`, `data`, and `.git` in addition to `.worktrees`. These are defensive — confirm these are all directories the watcher should never traverse.

## Verification

- `pubgolf-devctrl check go` — 0 lint issues
- `go vet ./tools/...` — passes
- `pubgolf-devctrl check proto` — not verified (`buf` not on PATH in the agent environment, but the `buf.yaml` change is syntactically valid)

## Test plan

- [ ] Run `pubgolf-devctrl check go` from the repo root with a worktree present in `.worktrees/` — lint should not report files from the worktree
- [ ] Run `pubgolf-devctrl check proto` — should still work normally
- [ ] Verify `buf lint` / `buf generate` ignore `.worktrees/` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)