### PR TITLE
Plan 01: Runner interface + dry-run flag for devctrl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11
+          version: v2.11.4
           args: ./tools/...
       - name: Test
         run: go test ./tools/lib/...
@@ -84,7 +84,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11
+          version: v2.11.4
           args: ./api/...
       - name: Test
         run: go test ./api/...

--- a/api/internal/lib/models/scoringcategory_test.go
+++ b/api/internal/lib/models/scoringcategory_test.go
@@ -160,8 +160,7 @@ func TestNullScoringCategory_Scan(t *testing.T) {
 
 		rows, err := tx.QueryContext(ctx, "SELECT value FROM enum_scoring_categories")
 		require.NoError(t, err)
-
-		defer rows.Close()
+		t.Cleanup(func() { rows.Close() })
 
 		for rows.Next() {
 			var s string

--- a/tools/lib/cmd/check.go
+++ b/tools/lib/cmd/check.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -28,18 +25,17 @@ var checkGoCmd = &cobra.Command{
 	Use:   "go",
 	Short: "Run golangci-lint on Go code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkGo(cmd.Context()), "execute `golangci-lint run` command")
+		guard(checkGo(cmd.Context(), runner), "execute `golangci-lint run` command")
 	},
 }
 
-func checkGo(ctx context.Context) error {
-	lint := exec.CommandContext(ctx, "golangci-lint", "run", "./api/...", "./tools/...")
-	lint.Stdout = os.Stdout
-	lint.Stderr = os.Stderr
-
-	err := lint.Run()
+func checkGo(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: "golangci-lint",
+		Args: []string{"run", "./api/...", "./tools/..."},
+	})
 	if err != nil {
-		return fmt.Errorf("run golangci-lint cmd: %w", err)
+		return fmtErr(err, "run golangci-lint cmd")
 	}
 
 	return nil
@@ -49,29 +45,27 @@ var checkWebCmd = &cobra.Command{
 	Use:   "web",
 	Short: "Run ESLint, Prettier, and svelte-check on web code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkWeb(cmd.Context()), "execute web lint commands")
+		guard(checkWeb(cmd.Context(), runner), "execute web lint commands")
 	},
 }
 
-func checkWeb(ctx context.Context) error {
-	ciLint := exec.CommandContext(ctx, "npm", "run", "ci:lint")
-	ciLint.Dir = "web-app"
-	ciLint.Stdout = os.Stdout
-	ciLint.Stderr = os.Stderr
-
-	err := ciLint.Run()
+func checkWeb(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: "npm",
+		Args: []string{"run", "ci:lint"},
+		Dir:  "web-app",
+	})
 	if err != nil {
-		return fmt.Errorf("run npm ci:lint cmd: %w", err)
+		return fmtErr(err, "run npm ci:lint cmd")
 	}
 
-	check := exec.CommandContext(ctx, "npm", "run", "check")
-	check.Dir = "web-app"
-	check.Stdout = os.Stdout
-	check.Stderr = os.Stderr
-
-	err = check.Run()
+	err = r.Run(ctx, Cmd{
+		Name: "npm",
+		Args: []string{"run", "check"},
+		Dir:  "web-app",
+	})
 	if err != nil {
-		return fmt.Errorf("run npm check cmd: %w", err)
+		return fmtErr(err, "run npm check cmd")
 	}
 
 	return nil
@@ -81,27 +75,25 @@ var checkProtoCmd = &cobra.Command{
 	Use:   "proto",
 	Short: "Run buf lint and format check on proto files",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkProto(cmd.Context()), "execute proto lint commands")
+		guard(checkProto(cmd.Context(), runner), "execute proto lint commands")
 	},
 }
 
-func checkProto(ctx context.Context) error {
-	lint := exec.CommandContext(ctx, "buf", "lint")
-	lint.Stdout = os.Stdout
-	lint.Stderr = os.Stderr
-
-	err := lint.Run()
+func checkProto(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: "buf",
+		Args: []string{"lint"},
+	})
 	if err != nil {
-		return fmt.Errorf("run buf lint cmd: %w", err)
+		return fmtErr(err, "run buf lint cmd")
 	}
 
-	format := exec.CommandContext(ctx, "buf", "format", "./proto/", "--diff", "--exit-code")
-	format.Stdout = os.Stdout
-	format.Stderr = os.Stderr
-
-	err = format.Run()
+	err = r.Run(ctx, Cmd{
+		Name: "buf",
+		Args: []string{"format", "./proto/", "--diff", "--exit-code"},
+	})
 	if err != nil {
-		return fmt.Errorf("run buf format cmd: %w", err)
+		return fmtErr(err, "run buf format cmd")
 	}
 
 	return nil

--- a/tools/lib/cmd/config.go
+++ b/tools/lib/cmd/config.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"net/url"
-	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -64,8 +63,8 @@ func (c *CLIConfig) setDefaults() {
 }
 
 // getDatabaseURL queries Doppler for DB connection details.
-func getDatabaseURL(ctx context.Context, driver DBDriver, project, env, prefix string, isMigrator bool) string {
-	vars := readDopplerVars(ctx, project, env, prefix, []string{
+func getDatabaseURL(ctx context.Context, r Runner, driver DBDriver, project, env, prefix string, isMigrator bool) string {
+	vars := readDopplerVars(ctx, r, project, env, prefix, []string{
 		"SQLITE_PATH",
 		"DB_USER",
 		"DB_PASSWORD",
@@ -100,20 +99,26 @@ func getDatabaseURL(ctx context.Context, driver DBDriver, project, env, prefix s
 }
 
 // readDopplerVars queries the Doppler CLI for a requested set of computed env vars.
-func readDopplerVars(ctx context.Context, project, env, prefix string, vars []string) map[string]string {
-	doppler := exec.CommandContext(ctx, "doppler",
-		"secrets",
-		"--project", project,
-		"--config", env,
-		"--json",
-	)
+// In dry-run mode, it records the command and returns an empty map (defaults will be used).
+func readDopplerVars(ctx context.Context, r Runner, project, env, prefix string, vars []string) map[string]string {
+	if isDryRun() {
+		// Record the command that would be executed, but return empty map so defaults are used.
+		_ = r.Run(ctx, Cmd{
+			Name: "doppler",
+			Args: []string{"secrets", "--project", project, "--config", env, "--json"},
+		})
+
+		return make(map[string]string)
+	}
 
 	var dopplerContent bytes.Buffer
 
-	doppler.Stdout = &dopplerContent
-	doppler.Stderr = os.Stderr
-
-	guard(doppler.Run(), "execute `doppler ...` command")
+	err := r.Run(ctx, Cmd{
+		Name:   "doppler",
+		Args:   []string{"secrets", "--project", project, "--config", env, "--json"},
+		Stdout: &dopplerContent,
+	})
+	guard(err, "execute `doppler ...` command")
 
 	var data map[string]any
 	guard(json.NewDecoder(&dopplerContent).Decode(&data), "read JSON output from doppler")
@@ -142,6 +147,10 @@ func readDopplerVars(ctx context.Context, project, env, prefix string, vars []st
 		}
 
 		outData[key] = v
+	}
+
+	if len(outData) > 0 {
+		log.Printf("Loaded %d secrets from Doppler", len(outData))
 	}
 
 	return outData

--- a/tools/lib/cmd/generate.go
+++ b/tools/lib/cmd/generate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -46,14 +45,14 @@ var generateProtoCmd = &cobra.Command{
 		watchFlag, err := cmd.Flags().GetBool("watch")
 		guard(err, "check '--watch' flag")
 
-		guard(generateProto(cmd.Context()), "execute `buf ...` command")
+		guard(generateProto(cmd.Context(), runner), "execute `buf ...` command")
 
 		if !watchFlag {
 			return
 		}
 
 		go watch(filepath.FromSlash("proto/"), "Proto codegen", func(_ watcher.Event) {
-			err := generateProto(context.Background())
+			err := generateProto(context.Background(), runner)
 			if err != nil {
 				log.Printf("Encountered error while running 'Proto codegen' task. Waiting to re-run...")
 			}
@@ -63,14 +62,13 @@ var generateProtoCmd = &cobra.Command{
 	},
 }
 
-func generateProto(ctx context.Context) error {
-	buf := exec.CommandContext(ctx, "buf", "generate", "--template", filepath.FromSlash("buf.gen.dev.yaml")) //nolint:gosec // Input is not dynamically provided by end-user.
-	buf.Stdout = os.Stdout
-	buf.Stderr = os.Stderr
-
-	err := buf.Run()
+func generateProto(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: "buf",
+		Args: []string{"generate", "--template", filepath.FromSlash("buf.gen.dev.yaml")},
+	})
 	if err != nil {
-		return fmt.Errorf("run buf generate cmd: %w", err)
+		return fmtErr(err, "run buf generate cmd")
 	}
 
 	return nil
@@ -83,14 +81,14 @@ var generateSQLcCmd = &cobra.Command{
 		watchFlag, err := cmd.Flags().GetBool("watch")
 		guard(err, "check '--watch' flag")
 
-		guard(generateSQLc(cmd.Context()), "execute `sqlc ...` command")
+		guard(generateSQLc(cmd.Context(), runner), "execute `sqlc ...` command")
 
 		if !watchFlag {
 			return
 		}
 
 		go watch(filepath.FromSlash("api/internal/db/"), "SQLc codegen", func(_ watcher.Event) {
-			err := generateSQLc(context.Background())
+			err := generateSQLc(context.Background(), runner)
 			if err != nil {
 				log.Printf("Encountered error while running 'SQLc codegen' task. Waiting to re-run...")
 			}
@@ -100,14 +98,13 @@ var generateSQLcCmd = &cobra.Command{
 	},
 }
 
-func generateSQLc(ctx context.Context) error {
-	sqlc := exec.CommandContext(ctx, "sqlc", "generate", "--file", filepath.FromSlash("api/internal/db/sqlc.yaml")) //nolint:gosec // Input is not dynamically provided by end-user.
-	sqlc.Stdout = os.Stdout
-	sqlc.Stderr = os.Stderr
-
-	err := sqlc.Run()
+func generateSQLc(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: "sqlc",
+		Args: []string{"generate", "--file", filepath.FromSlash("api/internal/db/sqlc.yaml")},
+	})
 	if err != nil {
-		return fmt.Errorf("run sqlc generate cmd: %w", err)
+		return fmtErr(err, "run sqlc generate cmd")
 	}
 
 	return nil
@@ -117,18 +114,17 @@ var generateEnumCmd = &cobra.Command{
 	Use:   "enum",
 	Short: "Generate enum stringers",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(generateEnum(cmd.Context(), "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")), "execute `enumer ...` command for ")
+		guard(generateEnum(cmd.Context(), runner, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")), "execute `enumer ...` command for ")
 	},
 }
 
-func generateEnum(ctx context.Context, typ, pkg string) error {
-	enumer := exec.CommandContext(ctx, "enumer", "-sql", "-transform", "snake-upper", "-type", typ, pkg)
-	enumer.Stdout = os.Stdout
-	enumer.Stderr = os.Stderr
-
-	err := enumer.Run()
+func generateEnum(ctx context.Context, r Runner, typ, pkg string) error {
+	err := r.Run(ctx, Cmd{
+		Name: "enumer",
+		Args: []string{"-sql", "-transform", "snake-upper", "-type", typ, pkg},
+	})
 	if err != nil {
-		return fmt.Errorf("run enumer cmd: %w", err)
+		return fmtErr(err, "run enumer cmd")
 	}
 
 	return nil
@@ -152,7 +148,7 @@ var generateDBCMockCmd = &cobra.Command{
 	Short: "Generate DBC mock",
 	Run: func(cmd *cobra.Command, _ []string) {
 		guard(
-			generateMock(cmd.Context(), "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")),
+			generateMock(cmd.Context(), runner, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")),
 			"generate mock DBC",
 		)
 	},
@@ -163,7 +159,7 @@ var generateDAOMockCmd = &cobra.Command{
 	Short: "Generate DAO interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
 		guard(
-			generateInterfaceAndMock(cmd.Context(), mockConfig{
+			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
 				targetStruct: "Queries",
 				ifaceName:    "QueryProvider",
 				ifaceComment: "QueryProvider describes all of the queries exposed by the DAO, to allow for testing mocks.",
@@ -180,7 +176,7 @@ var generateSMSMockCmd = &cobra.Command{
 	Short: "Generate SMS client interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
 		guard(
-			generateInterfaceAndMock(cmd.Context(), mockConfig{
+			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
 				targetStruct: "Client",
 				ifaceName:    "Messenger",
 				ifaceComment: "Messenger describes all of the operations exposed by the SMS client, to allow for testing mocks.",
@@ -200,13 +196,13 @@ type mockConfig struct {
 	pkgName      string
 }
 
-func generateInterfaceAndMock(ctx context.Context, mc mockConfig) error {
-	err := generateInterface(ctx, mc)
+func generateInterfaceAndMock(ctx context.Context, r Runner, mc mockConfig) error {
+	err := generateInterface(ctx, r, mc)
 	if err != nil {
 		return fmt.Errorf("generate interface: %w", err)
 	}
 
-	err = generateMock(ctx, mc.ifaceName, mc.genDir)
+	err = generateMock(ctx, r, mc.ifaceName, mc.genDir)
 	if err != nil {
 		return fmt.Errorf("generate mock: %w", err)
 	}
@@ -214,7 +210,7 @@ func generateInterfaceAndMock(ctx context.Context, mc mockConfig) error {
 	return nil
 }
 
-func generateInterface(ctx context.Context, mc mockConfig) error {
+func generateInterface(ctx context.Context, r Runner, mc mockConfig) error {
 	args := []string{
 		"--struct", mc.targetStruct,
 		"--iface", mc.ifaceName,
@@ -248,33 +244,29 @@ func generateInterface(ctx context.Context, mc mockConfig) error {
 		args = append(args, "--file", filepath.Join(mc.genDir, f.Name()))
 	}
 
-	iface := exec.CommandContext(ctx, "ifacemaker", args...)
-
-	iface.Stdout = os.Stdout
-	iface.Stderr = os.Stderr
-
-	err = iface.Run()
+	err = r.Run(ctx, Cmd{
+		Name: "ifacemaker",
+		Args: args,
+	})
 	if err != nil {
-		return fmt.Errorf("run interface generator command: %w", err)
+		return fmtErr(err, "run interface generator command")
 	}
 
 	return nil
 }
 
-func generateMock(ctx context.Context, ifaceName, genDir string) error {
-	mock := exec.CommandContext(ctx, "mockery",
-		"--dir", genDir,
-		"--name", ifaceName,
-		"--filename", "gen_mock.go",
-		"--inpackage",
-	)
-
-	mock.Stdout = os.Stdout
-	mock.Stderr = os.Stderr
-
-	err := mock.Run()
+func generateMock(ctx context.Context, r Runner, ifaceName, genDir string) error {
+	err := r.Run(ctx, Cmd{
+		Name: "mockery",
+		Args: []string{
+			"--dir", genDir,
+			"--name", ifaceName,
+			"--filename", "gen_mock.go",
+			"--inpackage",
+		},
+	})
 	if err != nil {
-		return fmt.Errorf("run mock generator command: %w", err)
+		return fmtErr(err, "run mock generator command")
 	}
 
 	return nil

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -50,7 +50,7 @@ func generateGoInstallers() []*cobra.Command {
 			Use:   n,
 			Short: fmt.Sprintf("Install the %q CLI tool", n),
 			Run: func(cmd *cobra.Command, _ []string) {
-				installWithGolang(cmd.Context(), runner, v)
+				guard(installWithGolang(cmd.Context(), runner, v), "install Go tool")
 			},
 		})
 	}
@@ -62,8 +62,8 @@ var installDopplerCmd = &cobra.Command{
 	Use:   "doppler",
 	Short: "Install the `doppler` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		installWithHomebrew(cmd.Context(), runner, "gnupg")
-		installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler")
+		guard(installWithHomebrew(cmd.Context(), runner, "gnupg"), "install gnupg")
+		guard(installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler"), "install doppler")
 	},
 }
 
@@ -71,20 +71,30 @@ var installBufCmd = &cobra.Command{
 	Use:   "buf",
 	Short: "Install the `buf` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf")
+		guard(installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf"), "install buf")
 	},
 }
 
-func installWithGolang(ctx context.Context, r Runner, pkg string) {
-	guard(r.Run(ctx, Cmd{
+func installWithGolang(ctx context.Context, r Runner, pkg string) error {
+	err := r.Run(ctx, Cmd{
 		Name: "go",
 		Args: []string{"install", pkg},
-	}), fmt.Sprintf("execute `go install ...` command for package '%s'", pkg))
+	})
+	if err != nil {
+		return fmtErr(err, fmt.Sprintf("run go install cmd for package '%s'", pkg))
+	}
+
+	return nil
 }
 
-func installWithHomebrew(ctx context.Context, r Runner, pkg string) {
-	guard(r.Run(ctx, Cmd{
+func installWithHomebrew(ctx context.Context, r Runner, pkg string) error {
+	err := r.Run(ctx, Cmd{
 		Name: "brew",
 		Args: []string{"install", pkg},
-	}), fmt.Sprintf("execute `brew install ...` command for package '%s'", pkg))
+	})
+	if err != nil {
+		return fmtErr(err, fmt.Sprintf("run brew install cmd for package '%s'", pkg))
+	}
+
+	return nil
 }

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -10,12 +10,12 @@ import (
 )
 
 var goTools = map[string]string{
-	"migrate":       "github.com/golang-migrate/migrate/v4/cmd/migrate@v4.17.0",
-	"sqlc":          "github.com/sqlc-dev/sqlc/cmd/sqlc@v1.24.0",
-	"mockery":       "github.com/vektra/mockery/v2@v2.42.2",
-	"ifacemaker":    "github.com/vburenin/ifacemaker@v1.2.1",
-	"enumer":        "github.com/dmarkham/enumer@v1.5.9",
-	"golangci-lint": "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3",
+	"migrate":       "github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1",
+	"sqlc":          "github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0",
+	"mockery":       "github.com/vektra/mockery/v2@v2.53.6",
+	"ifacemaker":    "github.com/vburenin/ifacemaker@v1.3.0",
+	"enumer":        "github.com/dmarkham/enumer@v1.6.3",
+	"golangci-lint": "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4",
 }
 
 func init() {

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -52,7 +50,7 @@ func generateGoInstallers() []*cobra.Command {
 			Use:   n,
 			Short: fmt.Sprintf("Install the %q CLI tool", n),
 			Run: func(cmd *cobra.Command, _ []string) {
-				installWithGolang(cmd.Context(), v)
+				installWithGolang(cmd.Context(), runner, v)
 			},
 		})
 	}
@@ -64,8 +62,8 @@ var installDopplerCmd = &cobra.Command{
 	Use:   "doppler",
 	Short: "Install the `doppler` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		installWithHomebrew(cmd.Context(), "gnupg")
-		installWithHomebrew(cmd.Context(), "dopplerhq/cli/doppler")
+		installWithHomebrew(cmd.Context(), runner, "gnupg")
+		installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler")
 	},
 }
 
@@ -73,20 +71,20 @@ var installBufCmd = &cobra.Command{
 	Use:   "buf",
 	Short: "Install the `buf` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		installWithHomebrew(cmd.Context(), "bufbuild/buf/buf")
+		installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf")
 	},
 }
 
-func installWithGolang(ctx context.Context, pkg string) {
-	installer := exec.CommandContext(ctx, "go", "install", pkg)
-	installer.Stdout = os.Stdout
-	installer.Stderr = os.Stderr
-	guard(installer.Run(), fmt.Sprintf("execute `go install ...` command for package '%s'", pkg))
+func installWithGolang(ctx context.Context, r Runner, pkg string) {
+	guard(r.Run(ctx, Cmd{
+		Name: "go",
+		Args: []string{"install", pkg},
+	}), fmt.Sprintf("execute `go install ...` command for package '%s'", pkg))
 }
 
-func installWithHomebrew(ctx context.Context, pkg string) {
-	installer := exec.CommandContext(ctx, "brew", "install", pkg)
-	installer.Stdout = os.Stdout
-	installer.Stderr = os.Stderr
-	guard(installer.Run(), fmt.Sprintf("execute `brew install ...` command for package '%s'", pkg))
+func installWithHomebrew(ctx context.Context, r Runner, pkg string) {
+	guard(r.Run(ctx, Cmd{
+		Name: "brew",
+		Args: []string{"install", pkg},
+	}), fmt.Sprintf("execute `brew install ...` command for package '%s'", pkg))
 }

--- a/tools/lib/cmd/migrate.go
+++ b/tools/lib/cmd/migrate.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -87,32 +86,29 @@ var migrateCreateCmd = &cobra.Command{
 	Short: "Create new migration files",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Creating migration files isn't supported via the programmatic API, so create using the following shell command: `migrate create -seq -ext 'sql' -dir "api/internal/db/migrations" "$1"`
-		migrator := exec.CommandContext(cmd.Context(), "migrate",
-			"create",
-			"-seq",
-			"-ext", "sql",
-			"-dir", migrationDirectory,
-			args[0],
-		)
-
-		var migratorContent bytes.Buffer
-
-		migrator.Stdout = os.Stdout
-		migrator.Stderr = io.MultiWriter(os.Stderr, &migratorContent)
-		guard(migrator.Run(), "execute `migrate ...` command")
-
-		outLines := strings.Split(migratorContent.String(), "\n")
-		for _, name := range outLines[:len(outLines)-1] {
-			f, err := os.OpenFile(name, os.O_RDWR, 0o644)
-			guard(err, "open migration file to add boilerplate")
-
-			defer f.Close()
-
-			_, err = f.WriteString("BEGIN;\n\n-- Migration logic goes here...\n\nCOMMIT;\n")
-			guard(err, "write boilerplate to migration file")
-		}
+		migrateCreate(cmd.Context(), runner, args[0])
 	},
+}
+
+func migrateCreate(ctx context.Context, r Runner, name string) {
+	var migratorContent bytes.Buffer
+
+	guard(r.Run(ctx, Cmd{
+		Name:   "migrate",
+		Args:   []string{"create", "-seq", "-ext", "sql", "-dir", migrationDirectory, name},
+		Stderr: io.MultiWriter(os.Stderr, &migratorContent),
+	}), "execute `migrate ...` command")
+
+	outLines := strings.Split(migratorContent.String(), "\n")
+	for _, name := range outLines[:len(outLines)-1] {
+		f, err := os.OpenFile(name, os.O_RDWR, 0o644)
+		guard(err, "open migration file to add boilerplate")
+
+		defer f.Close()
+
+		_, err = f.WriteString("BEGIN;\n\n-- Migration logic goes here...\n\nCOMMIT;\n")
+		guard(err, "write boilerplate to migration file")
+	}
 }
 
 var migrateFixCmd = &cobra.Command{
@@ -120,7 +116,7 @@ var migrateFixCmd = &cobra.Command{
 	Short: "Reset the migration state of a DB to a known valid migration version, assuming all migrations were transacted",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		dbURL := getDatabaseURL(cmd.Context(), config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, false)
+		dbURL := getDatabaseURL(cmd.Context(), runner, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, false)
 		db, err := sql.Open(config.DBDriver.driverString(false), dbURL)
 		guard(err, "open DB connection")
 
@@ -140,7 +136,7 @@ var migrateFixCmd = &cobra.Command{
 }
 
 func getMigrator(ctx context.Context) *migrate.Migrate {
-	dbURL := getDatabaseURL(ctx, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, true)
+	dbURL := getDatabaseURL(ctx, runner, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, true)
 	m, err := migrate.New(migrationSource, dbURL)
 	guard(err, "construct DB migrator")
 

--- a/tools/lib/cmd/root.go
+++ b/tools/lib/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/radovskyb/watcher"
@@ -17,10 +16,10 @@ import (
 
 // Internal plumbing.
 var (
-	// beginShutdown indicates we've received an OS signal to begin shutting down.
-	beginShutdown = make(chan os.Signal, 1)
 	// shuttingDown is a broadcast channel that closes to tell all processes to begin cleanup.
 	shuttingDown = make(chan struct{})
+	// shutdownOnce ensures triggerShutdown is called at most once.
+	shutdownOnce sync.Once
 )
 
 // Package parameters.
@@ -29,11 +28,9 @@ var (
 	installedToolsHash string
 	// config holds the provided configuration options.
 	config CLIConfig
+	// runner is the package-level Runner used by all command handlers.
+	runner Runner
 )
-
-func init() {
-	signal.Notify(beginShutdown, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-}
 
 // Execute is the entrypoint for calling the CLI.
 func Execute(toolsDirHash string, c CLIConfig) {
@@ -51,21 +48,40 @@ func Execute(toolsDirHash string, c CLIConfig) {
 	}
 }
 
+// triggerShutdown closes the shuttingDown channel exactly once.
+func triggerShutdown() {
+	shutdownOnce.Do(func() { close(shuttingDown) })
+}
+
 var rootCmd = &cobra.Command{
 	Use:   config.CLIName,
 	Short: "DevCtrl is a task runner for local dev",
 	Long:  `An opinionated task runner for personal use by @thedeerchild`,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		// Skip the update warning for the update command itself
-		if cmd.CommandPath() != " update" {
+		// Initialize the runner based on the --dry-run flag.
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		if dryRun {
+			runner = &DryRunner{}
+		} else {
+			runner = ExecRunner{}
+		}
+
+		// Skip the update warning for the update command itself and in dry-run mode.
+		if !dryRun && cmd.CommandPath() != " update" {
 			checkVersion()
 		}
 
 		go func() {
-			<-beginShutdown
-			close(shuttingDown)
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, os.Interrupt)
+			<-sigCh
+			triggerShutdown()
 		}()
 	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().Bool("dry-run", false, "Print commands that would be executed without running them")
 }
 
 func checkVersion() {

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -135,9 +135,11 @@ func dopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args 
 
 	if stopOnExit {
 		go func() {
-			if err := proc.Wait(); err != nil {
-				log.Printf("process exited with error: %v", err)
+			waitErr := proc.Wait()
+			if waitErr != nil {
+				log.Printf("process exited with error: %v", waitErr)
 			}
+
 			triggerShutdown()
 		}()
 	}

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -97,25 +97,32 @@ func watchableDopplerGoRun(cmd *cobra.Command, r Runner, project, env, bin strin
 	guard(err, "check '--watch' flag")
 
 	// Start initial process
-	proc := dopplerGoRun(cmd.Context(), r, project, env, bin, args, !watchFlag)
+	proc := startDopplerGoRun(cmd.Context(), r, project, env, bin, args)
 
-	// Launch watcher, if applicable.
-	if watchFlag {
-		go func() {
-			watch("api", "restart API server", func(_ watcher.Event) {
-				// Stop the old process and keep track of the new one.
-				proc.Stop()
-				proc = dopplerGoRun(context.Background(), r, project, env, bin, args, false)
-			})
-		}()
+	if !watchFlag {
+		// Wait for process to exit, then shut down.
+		waitErr := proc.Wait()
+		if waitErr != nil {
+			log.Printf("process exited with error: %v", waitErr)
+		}
+
+		return
 	}
 
-	// Hold process open
+	// Launch watcher to restart the process on file changes.
+	go func() {
+		watch("api", "restart API server", func(_ watcher.Event) {
+			proc.Stop()
+			proc = startDopplerGoRun(context.Background(), r, project, env, bin, args)
+		})
+	}()
+
+	// Hold process open until shutdown signal.
 	<-shuttingDown
 	proc.Stop()
 }
 
-func dopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args []string, stopOnExit bool) Process { //nolint:ireturn // Returns Process interface by design.
+func startDopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args []string) Process { //nolint:ireturn // Returns Process interface by design.
 	allArgs := append(
 		[]string{
 			"run",
@@ -132,17 +139,6 @@ func dopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args 
 		Args: allArgs,
 	})
 	guard(err, "execute `go run ...` command")
-
-	if stopOnExit {
-		go func() {
-			waitErr := proc.Wait()
-			if waitErr != nil {
-				log.Printf("process exited with error: %v", waitErr)
-			}
-
-			triggerShutdown()
-		}()
-	}
 
 	return proc
 }

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -43,10 +43,10 @@ var runAPIBgCmd = &cobra.Command{
 	Use:   "bg",
 	Short: "Run all supporting services for the API server",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName,
+		guard(dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName,
 			"api-db",
 			// "api-blob-storage",
-		)
+		), "execute `docker-compose up ...` command")
 	},
 }
 
@@ -54,7 +54,8 @@ var runAPIDatabaseCmd = &cobra.Command{
 	Use:   "api-db",
 	Short: "Run API server's DB instance",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName, "api-db")
+		guard(dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName, "api-db"),
+			"execute `docker-compose up ...` command")
 	},
 }
 
@@ -66,7 +67,7 @@ var runAPIDatabaseCmd = &cobra.Command{
 // 	},
 // }
 
-func dopplerDockerRun(ctx context.Context, r Runner, project, env string, services ...string) {
+func dopplerDockerRun(ctx context.Context, r Runner, project, env string, services ...string) error {
 	args := []string{
 		"run",
 		"--project", project,
@@ -80,10 +81,15 @@ func dopplerDockerRun(ctx context.Context, r Runner, project, env string, servic
 	}
 	args = append(args, services...)
 
-	guard(r.Run(ctx, Cmd{
+	err := r.Run(ctx, Cmd{
 		Name: "doppler",
 		Args: args,
-	}), "execute `docker-compose up ...` command")
+	})
+	if err != nil {
+		return fmtErr(err, "run docker-compose up cmd")
+	}
+
+	return nil
 }
 
 func watchableDopplerGoRun(cmd *cobra.Command, r Runner, project, env, bin string, args []string) {
@@ -129,7 +135,9 @@ func dopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args 
 
 	if stopOnExit {
 		go func() {
-			guard(proc.Wait(), "wait on process")
+			if err := proc.Wait(); err != nil {
+				log.Printf("process exited with error: %v", err)
+			}
 			triggerShutdown()
 		}()
 	}

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -3,10 +3,7 @@ package cmd
 import (
 	"context"
 	"log"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"syscall"
 
 	"github.com/radovskyb/watcher"
 	"github.com/spf13/cobra"
@@ -38,7 +35,7 @@ var runAPIServerCmd = &cobra.Command{
 	Short: "Run API server",
 	Run: func(cmd *cobra.Command, args []string) {
 		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-		watchableDopplerGoRun(cmd, config.ServerBinName, config.DopplerEnvName, binPath, args)
+		watchableDopplerGoRun(cmd, runner, config.ServerBinName, config.DopplerEnvName, binPath, args)
 	},
 }
 
@@ -46,7 +43,7 @@ var runAPIBgCmd = &cobra.Command{
 	Use:   "bg",
 	Short: "Run all supporting services for the API server",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerRun(cmd.Context(), config.ServerBinName, config.DopplerEnvName,
+		dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName,
 			"api-db",
 			// "api-blob-storage",
 		)
@@ -57,7 +54,7 @@ var runAPIDatabaseCmd = &cobra.Command{
 	Use:   "api-db",
 	Short: "Run API server's DB instance",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerRun(cmd.Context(), config.ServerBinName, config.DopplerEnvName, "api-db")
+		dopplerDockerRun(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName, "api-db")
 	},
 }
 
@@ -65,11 +62,11 @@ var runAPIDatabaseCmd = &cobra.Command{
 // 	Use:   "api-minio",
 // 	Short: "Run API server's blob storage (Minio) instance",
 // 	Run: func(cmd *cobra.Command, args []string) {
-// 		dopplerDockerRun(config.ServerBinName, config.DopplerEnvName, "api-blob-storage")
+// 		dopplerDockerRun(runner, config.ServerBinName, config.DopplerEnvName, "api-blob-storage")
 // 	},
 // }
 
-func dopplerDockerRun(ctx context.Context, project, env string, services ...string) {
+func dopplerDockerRun(ctx context.Context, r Runner, project, env string, services ...string) {
 	args := []string{
 		"run",
 		"--project", project,
@@ -83,39 +80,36 @@ func dopplerDockerRun(ctx context.Context, project, env string, services ...stri
 	}
 	args = append(args, services...)
 
-	doppler := exec.CommandContext(ctx, "doppler", args...)
-
-	doppler.Stdout = os.Stdout
-	doppler.Stderr = os.Stderr
-	doppler.Stdin = os.Stdin
-
-	guard(doppler.Run(), "execute `docker-compose up ...` command")
+	guard(r.Run(ctx, Cmd{
+		Name: "doppler",
+		Args: args,
+	}), "execute `docker-compose up ...` command")
 }
 
-func watchableDopplerGoRun(cmd *cobra.Command, project, env, bin string, args []string) {
+func watchableDopplerGoRun(cmd *cobra.Command, r Runner, project, env, bin string, args []string) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
 	guard(err, "check '--watch' flag")
 
 	// Start initial process
-	stopFn := dopplerGoRun(cmd.Context(), project, env, bin, args, !watchFlag)
+	proc := dopplerGoRun(cmd.Context(), r, project, env, bin, args, !watchFlag)
 
 	// Launch watcher, if applicable.
 	if watchFlag {
 		go func() {
 			watch("api", "restart API server", func(_ watcher.Event) {
-				// Start the old process and keep track of the new cleanup handler.
-				stopFn()
-				stopFn = dopplerGoRun(context.Background(), project, env, bin, args, false)
+				// Stop the old process and keep track of the new one.
+				proc.Stop()
+				proc = dopplerGoRun(context.Background(), r, project, env, bin, args, false)
 			})
 		}()
 	}
 
 	// Hold process open
 	<-shuttingDown
-	stopFn()
+	proc.Stop()
 }
 
-func dopplerGoRun(ctx context.Context, project, env, bin string, args []string, stopOnExit bool) func() {
+func dopplerGoRun(ctx context.Context, r Runner, project, env, bin string, args []string, stopOnExit bool) Process { //nolint:ireturn // Returns Process interface by design.
 	allArgs := append(
 		[]string{
 			"run",
@@ -125,34 +119,20 @@ func dopplerGoRun(ctx context.Context, project, env, bin string, args []string, 
 			"go", "run", bin,
 		}, args...)
 
-	doppler := exec.CommandContext(ctx, "doppler", allArgs...)
-
-	doppler.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	doppler.Stdout = os.Stdout
-	doppler.Stderr = os.Stderr
-	doppler.Stdin = os.Stdin
-
 	log.Printf("Starting '%s'...\n", bin)
-	guard(doppler.Start(), "execute `go run ...` command")
+
+	proc, err := r.Start(ctx, Cmd{
+		Name: "doppler",
+		Args: allArgs,
+	})
+	guard(err, "execute `go run ...` command")
 
 	if stopOnExit {
 		go func() {
-			guard(doppler.Wait(), "wait on process")
-			close(beginShutdown)
+			guard(proc.Wait(), "wait on process")
+			triggerShutdown()
 		}()
 	}
 
-	return func() {
-		log.Printf("Calling Doppler shutdown for pid %d...", doppler.Process.Pid)
-
-		pgid, err := syscall.Getpgid(doppler.Process.Pid)
-		if err != nil {
-			log.Println("Could not get pgid. Assuming process has already shut down.")
-
-			return
-		}
-
-		guard(syscall.Kill(-pgid, syscall.SIGKILL), "send SIGINT to running process")
-	}
+	return proc
 }

--- a/tools/lib/cmd/runner.go
+++ b/tools/lib/cmd/runner.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// Cmd describes a subprocess invocation.
+type Cmd struct {
+	Name   string
+	Args   []string
+	Dir    string    // working directory; empty uses process default
+	Env    []string  // additional env vars (KEY=VALUE); nil inherits parent env
+	Stdin  io.Reader // nil = os.Stdin
+	Stdout io.Writer // nil = os.Stdout
+	Stderr io.Writer // nil = os.Stderr
+}
+
+// String returns a shell-quoted representation of the command, suitable for
+// copy-pasting into a terminal.
+func (c Cmd) String() string {
+	parts := make([]string, 0, 1+len(c.Args))
+	parts = append(parts, c.Name)
+
+	for _, arg := range c.Args {
+		if needsQuoting(arg) {
+			parts = append(parts, "'"+strings.ReplaceAll(arg, "'", "'\\''")+"'")
+		} else {
+			parts = append(parts, arg)
+		}
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+
+	for _, c := range s {
+		if !isShellSafe(c) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isShellSafe(c rune) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '=' || c == ','
+}
+
+// Process represents a running subprocess started via Runner.Start.
+type Process interface {
+	// Wait blocks until the process exits and returns its error.
+	Wait() error
+	// Stop sends SIGINT to the process group for graceful shutdown.
+	Stop()
+}
+
+// Runner executes or records subprocess invocations.
+type Runner interface {
+	// Run executes (or records) a single command and waits for completion.
+	Run(ctx context.Context, cmd Cmd) error
+	// Start begins a long-running process and returns a Process handle.
+	Start(ctx context.Context, cmd Cmd) (Process, error)
+}
+
+// ExecRunner is the production Runner implementation that executes real subprocesses.
+type ExecRunner struct{}
+
+// Run executes a command and waits for completion.
+func (r ExecRunner) Run(ctx context.Context, c Cmd) error {
+	logCmd("exec", c)
+
+	cmd := r.buildCmd(ctx, c)
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("run %s: %w", c.Name, err)
+	}
+
+	return nil
+}
+
+// Start begins a long-running process with its own process group.
+func (r ExecRunner) Start(ctx context.Context, c Cmd) (Process, error) { //nolint:ireturn // Interface return is intentional for Runner contract.
+	logCmd("exec", c)
+
+	cmd := r.buildCmd(ctx, c)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	err := cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("start %s: %w", c.Name, err)
+	}
+
+	return &execProcess{cmd: cmd}, nil
+}
+
+func (r ExecRunner) buildCmd(ctx context.Context, c Cmd) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, c.Name, c.Args...) //nolint:gosec // Command construction is controlled by devctrl internals.
+
+	if c.Dir != "" {
+		cmd.Dir = c.Dir
+	}
+
+	if c.Stdin != nil {
+		cmd.Stdin = c.Stdin
+	} else {
+		cmd.Stdin = os.Stdin
+	}
+
+	if c.Stdout != nil {
+		cmd.Stdout = c.Stdout
+	} else {
+		cmd.Stdout = os.Stdout
+	}
+
+	if c.Stderr != nil {
+		cmd.Stderr = c.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
+	if len(c.Env) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), c.Env)
+	}
+
+	return cmd
+}
+
+type execProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *execProcess) Wait() error {
+	err := p.cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("wait %s: %w", p.cmd.Path, err)
+	}
+
+	return nil
+}
+
+func (p *execProcess) Stop() {
+	if p.cmd.Process == nil {
+		return
+	}
+
+	pgid, err := syscall.Getpgid(p.cmd.Process.Pid)
+	if err != nil {
+		return
+	}
+
+	_ = syscall.Kill(-pgid, syscall.SIGINT)
+}
+
+// DryRunner records commands without executing them. Used for --dry-run and tests.
+type DryRunner struct {
+	Recorded []Cmd
+	ErrorFor map[string]error // keyed on Cmd.Name
+}
+
+// Run records the command and returns the configured error (or nil).
+func (r *DryRunner) Run(_ context.Context, c Cmd) error {
+	r.Recorded = append(r.Recorded, c)
+	logCmd("dry-run", c)
+
+	if r.ErrorFor != nil {
+		if err, ok := r.ErrorFor[c.Name]; ok {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Start records the command and returns a no-op Process.
+func (r *DryRunner) Start(_ context.Context, c Cmd) (Process, error) { //nolint:ireturn // Interface return is intentional for Runner contract.
+	r.Recorded = append(r.Recorded, c)
+	logCmd("dry-run", c)
+
+	return &dryProcess{}, nil
+}
+
+type dryProcess struct{}
+
+func (p *dryProcess) Wait() error { return nil }
+func (p *dryProcess) Stop()       {}
+
+// logCmd logs a command invocation with the given prefix.
+func logCmd(prefix string, c Cmd) {
+	log.Printf("%s: %s", prefix, c.String())
+
+	if c.Dir != "" {
+		log.Printf("  dir: %s", c.Dir)
+	}
+
+	if len(c.Env) > 0 {
+		log.Printf("  env: %s", strings.Join(c.Env, " "))
+	}
+}
+
+// mergeEnv merges additional env vars into the parent environment.
+// Later values override earlier ones with the same key.
+func mergeEnv(parent, extra []string) []string {
+	m := make(map[string]string, len(parent)+len(extra))
+	order := make([]string, 0, len(parent)+len(extra))
+
+	addToMap := func(vars []string) {
+		for _, v := range vars {
+			k, _, _ := strings.Cut(v, "=")
+			if _, exists := m[k]; !exists {
+				order = append(order, k)
+			}
+
+			m[k] = v
+		}
+	}
+
+	addToMap(parent)
+	addToMap(extra)
+
+	result := make([]string, 0, len(order))
+	for _, k := range order {
+		result = append(result, m[k])
+	}
+
+	return result
+}
+
+// isDryRun reports whether the package-level runner is a DryRunner.
+func isDryRun() bool {
+	_, ok := runner.(*DryRunner)
+
+	return ok
+}
+
+// fmtErr wraps an error with a descriptive message, matching the existing guard pattern.
+func fmtErr(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%s: %w", msg, err)
+}

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -65,13 +65,13 @@ func TestDryRunnerRecordsCommands(t *testing.T) {
 		Name: "golangci-lint",
 		Args: []string{"run", "./api/...", "./tools/..."},
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	err = dr.Run(ctx, Cmd{
 		Name: "buf",
 		Args: []string{"generate", "--template", "buf.gen.dev.yaml"},
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	require.Len(t, dr.Recorded, 2)
 	assert.Equal(t, "golangci-lint", dr.Recorded[0].Name)
@@ -89,10 +89,10 @@ func TestDryRunnerStartRecordsAndReturnsProcess(t *testing.T) {
 		Args: []string{"run", "--", "go", "run", "./api/cmd/server"},
 	})
 	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
+	assert.Len(t, dr.Recorded, 1)
 
 	// Process.Wait and Process.Stop should be no-ops.
-	assert.NoError(t, proc.Wait())
+	require.NoError(t, proc.Wait())
 	proc.Stop() // should not panic
 }
 
@@ -107,10 +107,10 @@ func TestDryRunnerErrorFor(t *testing.T) {
 	ctx := context.Background()
 
 	err := dr.Run(ctx, Cmd{Name: "golangci-lint", Args: []string{"run"}})
-	assert.ErrorIs(t, err, errSimulated)
+	require.ErrorIs(t, err, errSimulated)
 
 	err = dr.Run(ctx, Cmd{Name: "buf", Args: []string{"lint"}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, dr.Recorded, 2)
 }
@@ -205,7 +205,7 @@ func TestMergeEnv(t *testing.T) {
 
 	result := mergeEnv(parent, extra)
 
-	require.Len(t, result, 4)
+	assert.Len(t, result, 4)
 
 	resultMap := make(map[string]string, len(result))
 	for _, v := range result {
@@ -237,8 +237,8 @@ func TestDopplerDockerStopCommandConstruction(t *testing.T) {
 
 	dr := &DryRunner{}
 
-	dopplerDockerStop(context.Background(), dr, "test-project", "dev")
-
+	err := dopplerDockerStop(context.Background(), dr, "test-project", "dev")
+	require.NoError(t, err)
 	require.Len(t, dr.Recorded, 1)
 
 	cmd := dr.Recorded[0]

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -115,88 +115,6 @@ func TestDryRunnerErrorFor(t *testing.T) {
 	assert.Len(t, dr.Recorded, 2)
 }
 
-func TestCheckGoCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := checkGo(ctx, dr)
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
-
-	cmd := dr.Recorded[0]
-	assert.Equal(t, "golangci-lint", cmd.Name)
-	require.NotEmpty(t, cmd.Args)
-	assert.Equal(t, "run", cmd.Args[0])
-}
-
-func TestCheckProtoCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := checkProto(ctx, dr)
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 2)
-
-	assert.Equal(t, "buf", dr.Recorded[0].Name)
-	assert.Equal(t, "lint", dr.Recorded[0].Args[0])
-	assert.Equal(t, "buf", dr.Recorded[1].Name)
-	assert.Equal(t, "format", dr.Recorded[1].Args[0])
-}
-
-func TestCheckWebCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := checkWeb(ctx, dr)
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 2)
-
-	assert.Equal(t, "web-app", dr.Recorded[0].Dir)
-	assert.Equal(t, "web-app", dr.Recorded[1].Dir)
-}
-
-func TestGenerateProtoCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := generateProto(ctx, dr)
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
-	assert.Equal(t, "buf", dr.Recorded[0].Name)
-}
-
-func TestGenerateSQLcCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := generateSQLc(ctx, dr)
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
-	assert.Equal(t, "sqlc", dr.Recorded[0].Name)
-}
-
-func TestGenerateEnumCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-	ctx := context.Background()
-
-	err := generateEnum(ctx, dr, "ScoringCategory", "./api/internal/lib/models")
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
-	assert.Equal(t, "enumer", dr.Recorded[0].Name)
-}
-
 func TestMergeEnv(t *testing.T) {
 	t.Parallel()
 
@@ -230,20 +148,6 @@ func splitEnvVar(s string) [2]string {
 	}
 
 	return [2]string{s[:i], s[i+1:]}
-}
-
-func TestDopplerDockerStopCommandConstruction(t *testing.T) {
-	t.Parallel()
-
-	dr := &DryRunner{}
-
-	err := dopplerDockerStop(context.Background(), dr, "test-project", "dev")
-	require.NoError(t, err)
-	require.Len(t, dr.Recorded, 1)
-
-	cmd := dr.Recorded[0]
-	assert.Equal(t, "doppler", cmd.Name)
-	assert.Contains(t, cmd.Args, "down")
 }
 
 func TestReadDopplerVarsDryRunReturnsEmptyMap(t *testing.T) {

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -1,0 +1,369 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+)
+
+var errSimulated = errors.New("simulated failure")
+
+func TestCmdString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  Cmd
+		want string
+	}{
+		{
+			name: "simple command",
+			cmd:  Cmd{Name: "golangci-lint", Args: []string{"run", "./api/...", "./tools/..."}},
+			want: "golangci-lint run ./api/... ./tools/...",
+		},
+		{
+			name: "command with spaces in args",
+			cmd:  Cmd{Name: "ifacemaker", Args: []string{"--iface-comment", "This is a comment"}},
+			want: "ifacemaker --iface-comment 'This is a comment'",
+		},
+		{
+			name: "command with single quotes in args",
+			cmd:  Cmd{Name: "echo", Args: []string{"it's"}},
+			want: `echo 'it'\''s'`,
+		},
+		{
+			name: "command with empty arg",
+			cmd:  Cmd{Name: "test", Args: []string{"--flag", ""}},
+			want: "test --flag ''",
+		},
+		{
+			name: "command with no args",
+			cmd:  Cmd{Name: "buf"},
+			want: "buf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.cmd.String()
+			if got != tt.want {
+				t.Errorf("Cmd.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDryRunnerRecordsCommands(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := dr.Run(ctx, Cmd{
+		Name: "golangci-lint",
+		Args: []string{"run", "./api/...", "./tools/..."},
+	})
+	if err != nil {
+		t.Fatalf("DryRunner.Run() returned error: %v", err)
+	}
+
+	err = dr.Run(ctx, Cmd{
+		Name: "buf",
+		Args: []string{"generate", "--template", "buf.gen.dev.yaml"},
+	})
+	if err != nil {
+		t.Fatalf("DryRunner.Run() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 2 {
+		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
+	}
+
+	if dr.Recorded[0].Name != "golangci-lint" {
+		t.Errorf("first command name = %q, want %q", dr.Recorded[0].Name, "golangci-lint")
+	}
+
+	if dr.Recorded[1].Name != "buf" {
+		t.Errorf("second command name = %q, want %q", dr.Recorded[1].Name, "buf")
+	}
+}
+
+func TestDryRunnerStartRecordsAndReturnsProcess(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	proc, err := dr.Start(ctx, Cmd{
+		Name: "doppler",
+		Args: []string{"run", "--", "go", "run", "./api/cmd/server"},
+	})
+	if err != nil {
+		t.Fatalf("DryRunner.Start() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	// Process.Wait and Process.Stop should be no-ops.
+	waitErr := proc.Wait()
+	if waitErr != nil {
+		t.Errorf("dryProcess.Wait() returned error: %v", waitErr)
+	}
+
+	proc.Stop() // should not panic
+}
+
+func TestDryRunnerErrorFor(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"golangci-lint": errSimulated,
+		},
+	}
+	ctx := context.Background()
+
+	err := dr.Run(ctx, Cmd{Name: "golangci-lint", Args: []string{"run"}})
+	if !errors.Is(err, errSimulated) {
+		t.Errorf("expected simulated error, got: %v", err)
+	}
+
+	err = dr.Run(ctx, Cmd{Name: "buf", Args: []string{"lint"}})
+	if err != nil {
+		t.Errorf("expected nil error for buf, got: %v", err)
+	}
+
+	if len(dr.Recorded) != 2 {
+		t.Errorf("expected 2 recorded commands, got %d", len(dr.Recorded))
+	}
+}
+
+func TestCheckGoCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := checkGo(ctx, dr)
+	if err != nil {
+		t.Fatalf("checkGo() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	cmd := dr.Recorded[0]
+	if cmd.Name != "golangci-lint" {
+		t.Errorf("command name = %q, want %q", cmd.Name, "golangci-lint")
+	}
+
+	if len(cmd.Args) < 1 || cmd.Args[0] != "run" {
+		t.Errorf("expected first arg to be 'run', got %v", cmd.Args)
+	}
+}
+
+func TestCheckProtoCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := checkProto(ctx, dr)
+	if err != nil {
+		t.Fatalf("checkProto() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 2 {
+		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
+	}
+
+	if dr.Recorded[0].Name != "buf" || dr.Recorded[0].Args[0] != "lint" {
+		t.Errorf("first command should be 'buf lint', got %s %v", dr.Recorded[0].Name, dr.Recorded[0].Args)
+	}
+
+	if dr.Recorded[1].Name != "buf" || dr.Recorded[1].Args[0] != "format" {
+		t.Errorf("second command should be 'buf format', got %s %v", dr.Recorded[1].Name, dr.Recorded[1].Args)
+	}
+}
+
+func TestCheckWebCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := checkWeb(ctx, dr)
+	if err != nil {
+		t.Fatalf("checkWeb() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 2 {
+		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
+	}
+
+	if dr.Recorded[0].Dir != "web-app" {
+		t.Errorf("first command dir = %q, want %q", dr.Recorded[0].Dir, "web-app")
+	}
+
+	if dr.Recorded[1].Dir != "web-app" {
+		t.Errorf("second command dir = %q, want %q", dr.Recorded[1].Dir, "web-app")
+	}
+}
+
+func TestGenerateProtoCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := generateProto(ctx, dr)
+	if err != nil {
+		t.Fatalf("generateProto() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	cmd := dr.Recorded[0]
+	if cmd.Name != "buf" {
+		t.Errorf("command name = %q, want %q", cmd.Name, "buf")
+	}
+}
+
+func TestGenerateSQLcCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := generateSQLc(ctx, dr)
+	if err != nil {
+		t.Fatalf("generateSQLc() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	if dr.Recorded[0].Name != "sqlc" {
+		t.Errorf("command name = %q, want %q", dr.Recorded[0].Name, "sqlc")
+	}
+}
+
+func TestGenerateEnumCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ctx := context.Background()
+
+	err := generateEnum(ctx, dr, "ScoringCategory", "./api/internal/lib/models")
+	if err != nil {
+		t.Fatalf("generateEnum() returned error: %v", err)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	cmd := dr.Recorded[0]
+	if cmd.Name != "enumer" {
+		t.Errorf("command name = %q, want %q", cmd.Name, "enumer")
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	t.Parallel()
+
+	parent := []string{"A=1", "B=2", "C=3"}
+	extra := []string{"B=override", "D=4"}
+
+	result := mergeEnv(parent, extra)
+
+	expected := map[string]string{
+		"A": "1",
+		"B": "override",
+		"C": "3",
+		"D": "4",
+	}
+
+	if len(result) != len(expected) {
+		t.Fatalf("expected %d env vars, got %d", len(expected), len(result))
+	}
+
+	for _, v := range result {
+		parts := splitEnvVar(v)
+		if want, ok := expected[parts[0]]; ok {
+			if parts[1] != want {
+				t.Errorf("env %s = %q, want %q", parts[0], parts[1], want)
+			}
+		} else {
+			t.Errorf("unexpected env var: %s", v)
+		}
+	}
+}
+
+func splitEnvVar(s string) [2]string {
+	i := 0
+	for i < len(s) && s[i] != '=' {
+		i++
+	}
+
+	if i >= len(s) {
+		return [2]string{s, ""}
+	}
+
+	return [2]string{s[:i], s[i+1:]}
+}
+
+func TestDopplerDockerStopCommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+
+	dopplerDockerStop(context.Background(), dr, "test-project", "dev")
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	cmd := dr.Recorded[0]
+	if cmd.Name != "doppler" {
+		t.Errorf("command name = %q, want %q", cmd.Name, "doppler")
+	}
+
+	if !slices.Contains(cmd.Args, "down") {
+		t.Error("expected 'down' in command args")
+	}
+}
+
+func TestReadDopplerVarsDryRunReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	// Use a local DryRunner and set the package-level runner temporarily.
+	origRunner := runner
+	dr := &DryRunner{}
+	runner = dr
+
+	defer func() { runner = origRunner }()
+
+	result := readDopplerVars(context.Background(), dr, "test-project", "dev", "PREFIX_", []string{"DB_HOST"})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map in dry-run mode, got %v", result)
+	}
+
+	if len(dr.Recorded) != 1 {
+		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
+	}
+
+	if dr.Recorded[0].Name != "doppler" {
+		t.Errorf("expected doppler command to be recorded, got %q", dr.Recorded[0].Name)
+	}
+}

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -65,13 +65,13 @@ func TestDryRunnerRecordsCommands(t *testing.T) {
 		Name: "golangci-lint",
 		Args: []string{"run", "./api/...", "./tools/..."},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = dr.Run(ctx, Cmd{
 		Name: "buf",
 		Args: []string{"generate", "--template", "buf.gen.dev.yaml"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	require.Len(t, dr.Recorded, 2)
 	assert.Equal(t, "golangci-lint", dr.Recorded[0].Name)

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"errors"
-	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var errSimulated = errors.New("simulated failure")
@@ -48,10 +50,7 @@ func TestCmdString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tt.cmd.String()
-			if got != tt.want {
-				t.Errorf("Cmd.String() = %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.cmd.String())
 		})
 	}
 }
@@ -66,29 +65,17 @@ func TestDryRunnerRecordsCommands(t *testing.T) {
 		Name: "golangci-lint",
 		Args: []string{"run", "./api/...", "./tools/..."},
 	})
-	if err != nil {
-		t.Fatalf("DryRunner.Run() returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	err = dr.Run(ctx, Cmd{
 		Name: "buf",
 		Args: []string{"generate", "--template", "buf.gen.dev.yaml"},
 	})
-	if err != nil {
-		t.Fatalf("DryRunner.Run() returned error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if len(dr.Recorded) != 2 {
-		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
-	}
-
-	if dr.Recorded[0].Name != "golangci-lint" {
-		t.Errorf("first command name = %q, want %q", dr.Recorded[0].Name, "golangci-lint")
-	}
-
-	if dr.Recorded[1].Name != "buf" {
-		t.Errorf("second command name = %q, want %q", dr.Recorded[1].Name, "buf")
-	}
+	require.Len(t, dr.Recorded, 2)
+	assert.Equal(t, "golangci-lint", dr.Recorded[0].Name)
+	assert.Equal(t, "buf", dr.Recorded[1].Name)
 }
 
 func TestDryRunnerStartRecordsAndReturnsProcess(t *testing.T) {
@@ -101,20 +88,11 @@ func TestDryRunnerStartRecordsAndReturnsProcess(t *testing.T) {
 		Name: "doppler",
 		Args: []string{"run", "--", "go", "run", "./api/cmd/server"},
 	})
-	if err != nil {
-		t.Fatalf("DryRunner.Start() returned error: %v", err)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
 
 	// Process.Wait and Process.Stop should be no-ops.
-	waitErr := proc.Wait()
-	if waitErr != nil {
-		t.Errorf("dryProcess.Wait() returned error: %v", waitErr)
-	}
-
+	assert.NoError(t, proc.Wait())
 	proc.Stop() // should not panic
 }
 
@@ -129,18 +107,12 @@ func TestDryRunnerErrorFor(t *testing.T) {
 	ctx := context.Background()
 
 	err := dr.Run(ctx, Cmd{Name: "golangci-lint", Args: []string{"run"}})
-	if !errors.Is(err, errSimulated) {
-		t.Errorf("expected simulated error, got: %v", err)
-	}
+	assert.ErrorIs(t, err, errSimulated)
 
 	err = dr.Run(ctx, Cmd{Name: "buf", Args: []string{"lint"}})
-	if err != nil {
-		t.Errorf("expected nil error for buf, got: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if len(dr.Recorded) != 2 {
-		t.Errorf("expected 2 recorded commands, got %d", len(dr.Recorded))
-	}
+	assert.Len(t, dr.Recorded, 2)
 }
 
 func TestCheckGoCommandConstruction(t *testing.T) {
@@ -150,22 +122,13 @@ func TestCheckGoCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := checkGo(ctx, dr)
-	if err != nil {
-		t.Fatalf("checkGo() returned error: %v", err)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
 
 	cmd := dr.Recorded[0]
-	if cmd.Name != "golangci-lint" {
-		t.Errorf("command name = %q, want %q", cmd.Name, "golangci-lint")
-	}
-
-	if len(cmd.Args) < 1 || cmd.Args[0] != "run" {
-		t.Errorf("expected first arg to be 'run', got %v", cmd.Args)
-	}
+	assert.Equal(t, "golangci-lint", cmd.Name)
+	require.NotEmpty(t, cmd.Args)
+	assert.Equal(t, "run", cmd.Args[0])
 }
 
 func TestCheckProtoCommandConstruction(t *testing.T) {
@@ -175,21 +138,13 @@ func TestCheckProtoCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := checkProto(ctx, dr)
-	if err != nil {
-		t.Fatalf("checkProto() returned error: %v", err)
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 2)
 
-	if len(dr.Recorded) != 2 {
-		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
-	}
-
-	if dr.Recorded[0].Name != "buf" || dr.Recorded[0].Args[0] != "lint" {
-		t.Errorf("first command should be 'buf lint', got %s %v", dr.Recorded[0].Name, dr.Recorded[0].Args)
-	}
-
-	if dr.Recorded[1].Name != "buf" || dr.Recorded[1].Args[0] != "format" {
-		t.Errorf("second command should be 'buf format', got %s %v", dr.Recorded[1].Name, dr.Recorded[1].Args)
-	}
+	assert.Equal(t, "buf", dr.Recorded[0].Name)
+	assert.Equal(t, "lint", dr.Recorded[0].Args[0])
+	assert.Equal(t, "buf", dr.Recorded[1].Name)
+	assert.Equal(t, "format", dr.Recorded[1].Args[0])
 }
 
 func TestCheckWebCommandConstruction(t *testing.T) {
@@ -199,21 +154,11 @@ func TestCheckWebCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := checkWeb(ctx, dr)
-	if err != nil {
-		t.Fatalf("checkWeb() returned error: %v", err)
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 2)
 
-	if len(dr.Recorded) != 2 {
-		t.Fatalf("expected 2 recorded commands, got %d", len(dr.Recorded))
-	}
-
-	if dr.Recorded[0].Dir != "web-app" {
-		t.Errorf("first command dir = %q, want %q", dr.Recorded[0].Dir, "web-app")
-	}
-
-	if dr.Recorded[1].Dir != "web-app" {
-		t.Errorf("second command dir = %q, want %q", dr.Recorded[1].Dir, "web-app")
-	}
+	assert.Equal(t, "web-app", dr.Recorded[0].Dir)
+	assert.Equal(t, "web-app", dr.Recorded[1].Dir)
 }
 
 func TestGenerateProtoCommandConstruction(t *testing.T) {
@@ -223,18 +168,9 @@ func TestGenerateProtoCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := generateProto(ctx, dr)
-	if err != nil {
-		t.Fatalf("generateProto() returned error: %v", err)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
-
-	cmd := dr.Recorded[0]
-	if cmd.Name != "buf" {
-		t.Errorf("command name = %q, want %q", cmd.Name, "buf")
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
+	assert.Equal(t, "buf", dr.Recorded[0].Name)
 }
 
 func TestGenerateSQLcCommandConstruction(t *testing.T) {
@@ -244,17 +180,9 @@ func TestGenerateSQLcCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := generateSQLc(ctx, dr)
-	if err != nil {
-		t.Fatalf("generateSQLc() returned error: %v", err)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
-
-	if dr.Recorded[0].Name != "sqlc" {
-		t.Errorf("command name = %q, want %q", dr.Recorded[0].Name, "sqlc")
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
+	assert.Equal(t, "sqlc", dr.Recorded[0].Name)
 }
 
 func TestGenerateEnumCommandConstruction(t *testing.T) {
@@ -264,18 +192,9 @@ func TestGenerateEnumCommandConstruction(t *testing.T) {
 	ctx := context.Background()
 
 	err := generateEnum(ctx, dr, "ScoringCategory", "./api/internal/lib/models")
-	if err != nil {
-		t.Fatalf("generateEnum() returned error: %v", err)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
-
-	cmd := dr.Recorded[0]
-	if cmd.Name != "enumer" {
-		t.Errorf("command name = %q, want %q", cmd.Name, "enumer")
-	}
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
+	assert.Equal(t, "enumer", dr.Recorded[0].Name)
 }
 
 func TestMergeEnv(t *testing.T) {
@@ -286,27 +205,18 @@ func TestMergeEnv(t *testing.T) {
 
 	result := mergeEnv(parent, extra)
 
-	expected := map[string]string{
-		"A": "1",
-		"B": "override",
-		"C": "3",
-		"D": "4",
-	}
+	require.Len(t, result, 4)
 
-	if len(result) != len(expected) {
-		t.Fatalf("expected %d env vars, got %d", len(expected), len(result))
-	}
-
+	resultMap := make(map[string]string, len(result))
 	for _, v := range result {
 		parts := splitEnvVar(v)
-		if want, ok := expected[parts[0]]; ok {
-			if parts[1] != want {
-				t.Errorf("env %s = %q, want %q", parts[0], parts[1], want)
-			}
-		} else {
-			t.Errorf("unexpected env var: %s", v)
-		}
+		resultMap[parts[0]] = parts[1]
 	}
+
+	assert.Equal(t, "1", resultMap["A"])
+	assert.Equal(t, "override", resultMap["B"])
+	assert.Equal(t, "3", resultMap["C"])
+	assert.Equal(t, "4", resultMap["D"])
 }
 
 func splitEnvVar(s string) [2]string {
@@ -329,18 +239,11 @@ func TestDopplerDockerStopCommandConstruction(t *testing.T) {
 
 	dopplerDockerStop(context.Background(), dr, "test-project", "dev")
 
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
+	require.Len(t, dr.Recorded, 1)
 
 	cmd := dr.Recorded[0]
-	if cmd.Name != "doppler" {
-		t.Errorf("command name = %q, want %q", cmd.Name, "doppler")
-	}
-
-	if !slices.Contains(cmd.Args, "down") {
-		t.Error("expected 'down' in command args")
-	}
+	assert.Equal(t, "doppler", cmd.Name)
+	assert.Contains(t, cmd.Args, "down")
 }
 
 func TestReadDopplerVarsDryRunReturnsEmptyMap(t *testing.T) {
@@ -355,15 +258,7 @@ func TestReadDopplerVarsDryRunReturnsEmptyMap(t *testing.T) {
 
 	result := readDopplerVars(context.Background(), dr, "test-project", "dev", "PREFIX_", []string{"DB_HOST"})
 
-	if len(result) != 0 {
-		t.Errorf("expected empty map in dry-run mode, got %v", result)
-	}
-
-	if len(dr.Recorded) != 1 {
-		t.Fatalf("expected 1 recorded command, got %d", len(dr.Recorded))
-	}
-
-	if dr.Recorded[0].Name != "doppler" {
-		t.Errorf("expected doppler command to be recorded, got %q", dr.Recorded[0].Name)
-	}
+	assert.Empty(t, result)
+	require.Len(t, dr.Recorded, 1)
+	assert.Equal(t, "doppler", dr.Recorded[0].Name)
 }

--- a/tools/lib/cmd/stop.go
+++ b/tools/lib/cmd/stop.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -16,25 +13,23 @@ func init() {
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: fmt.Sprintf("Stop all background processes started with `%s run ...`", config.CLIName),
+	Short: "Stop all background processes started with `devctrl run ...`",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerStop(cmd.Context(), config.ServerBinName, config.DopplerEnvName)
+		dopplerDockerStop(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName)
 	},
 }
 
-func dopplerDockerStop(ctx context.Context, project, env string) {
-	doppler := exec.CommandContext(ctx, "doppler",
-		"run",
-		"--project", project,
-		"--config", env,
-		"--",
-		"docker-compose",
-		"--file", filepath.FromSlash("./infra/docker-compose.dev.yaml"),
-		"down")
-
-	doppler.Stdout = os.Stdout
-	doppler.Stderr = os.Stderr
-	doppler.Stdin = os.Stdin
-
-	guard(doppler.Run(), "execute `docker-compose up ...` command")
+func dopplerDockerStop(ctx context.Context, r Runner, project, env string) {
+	guard(r.Run(ctx, Cmd{
+		Name: "doppler",
+		Args: []string{
+			"run",
+			"--project", project,
+			"--config", env,
+			"--",
+			"docker-compose",
+			"--file", filepath.FromSlash("./infra/docker-compose.dev.yaml"),
+			"down",
+		},
+	}), "execute `docker-compose down ...` command")
 }

--- a/tools/lib/cmd/stop.go
+++ b/tools/lib/cmd/stop.go
@@ -15,12 +15,13 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop all background processes started with `devctrl run ...`",
 	Run: func(cmd *cobra.Command, _ []string) {
-		dopplerDockerStop(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName)
+		guard(dopplerDockerStop(cmd.Context(), runner, config.ServerBinName, config.DopplerEnvName),
+			"execute `docker-compose down ...` command")
 	},
 }
 
-func dopplerDockerStop(ctx context.Context, r Runner, project, env string) {
-	guard(r.Run(ctx, Cmd{
+func dopplerDockerStop(ctx context.Context, r Runner, project, env string) error {
+	err := r.Run(ctx, Cmd{
 		Name: "doppler",
 		Args: []string{
 			"run",
@@ -31,5 +32,10 @@ func dopplerDockerStop(ctx context.Context, r Runner, project, env string) {
 			"--file", filepath.FromSlash("./infra/docker-compose.dev.yaml"),
 			"down",
 		},
-	}), "execute `docker-compose down ...` command")
+	})
+	if err != nil {
+		return fmtErr(err, "run docker-compose down cmd")
+	}
+
+	return nil
 }

--- a/tools/lib/cmd/test.go
+++ b/tools/lib/cmd/test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 
 	"github.com/radovskyb/watcher"
 	"github.com/spf13/cobra"
@@ -76,13 +75,10 @@ var testCmd = &cobra.Command{
 			guard(os.MkdirAll(coverageDir, 0o755), "make new output dir: %w")
 		}
 
-		tester := exec.CommandContext(cmd.Context(), "doppler", args...)
-
-		tester.Stdout = os.Stdout
-		tester.Stderr = os.Stderr
-		tester.Stdin = os.Stdin
-
-		err = tester.Run()
+		err = runner.Run(cmd.Context(), Cmd{
+			Name: "doppler",
+			Args: args,
+		})
 		if err != nil {
 			// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
 			exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
@@ -92,16 +88,10 @@ var testCmd = &cobra.Command{
 		}
 
 		if coverageFlag {
-			cover := exec.CommandContext(cmd.Context(), "go",
-				"tool", "cover",
-				"-html", coverageFile,
-			)
-
-			cover.Stdout = os.Stdout
-			cover.Stderr = os.Stderr
-			cover.Stdin = os.Stdin
-
-			guard(cover.Run(), "execute `go tool cover ...` command")
+			guard(runner.Run(cmd.Context(), Cmd{
+				Name: "go",
+				Args: []string{"tool", "cover", "-html", coverageFile},
+			}), "execute `go tool cover ...` command")
 		}
 	},
 }
@@ -117,14 +107,14 @@ var testE2ECmd = &cobra.Command{
 		guard(err, "check '--local' flag")
 
 		// Start initial process.
-		stopFn := runE2ETest(cmd.Context(), !watchFlag, localFlag)
+		proc := runE2ETest(cmd.Context(), runner, !watchFlag, localFlag)
 
 		// Launch watcher, if applicable.
 		if watchFlag {
 			go func() {
 				watch("api", "e2e test", func(_ watcher.Event) {
-					stopFn()
-					stopFn = runE2ETest(context.Background(), false, localFlag)
+					proc.Stop()
+					proc = runE2ETest(context.Background(), runner, false, localFlag)
 				})
 			}()
 		}
@@ -134,7 +124,7 @@ var testE2ECmd = &cobra.Command{
 	},
 }
 
-func runE2ETest(ctx context.Context, stopOnExit, localOnly bool) func() {
+func runE2ETest(ctx context.Context, r Runner, stopOnExit, localOnly bool) Process { //nolint:ireturn // Returns Process interface by design.
 	args := []string{
 		"run",
 		"--project", config.ServerBinName,
@@ -165,17 +155,12 @@ func runE2ETest(ctx context.Context, stopOnExit, localOnly bool) func() {
 		}...)
 	}
 
-	tester := exec.CommandContext(ctx, "doppler", args...)
-
-	tester.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	tester.Stdout = os.Stdout
-	tester.Stderr = os.Stderr
-	tester.Stdin = os.Stdin
-
 	log.Println("Starting e2e test run...")
 
-	err := tester.Start()
+	proc, err := r.Start(ctx, Cmd{
+		Name: "doppler",
+		Args: args,
+	})
 	if err != nil {
 		// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
 		exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
@@ -186,9 +171,7 @@ func runE2ETest(ctx context.Context, stopOnExit, localOnly bool) func() {
 
 	if stopOnExit {
 		go func() {
-			defer close(beginShutdown)
-
-			err := tester.Wait()
+			err := proc.Wait()
 			if err != nil {
 				// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
 				exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
@@ -196,16 +179,10 @@ func runE2ETest(ctx context.Context, stopOnExit, localOnly bool) func() {
 					guard(err, "execute `go test ...` command")
 				}
 			}
+
+			triggerShutdown()
 		}()
 	}
 
-	return func() {
-		pgid, err := syscall.Getpgid(tester.Process.Pid)
-		if err != nil {
-			// Previous run has already finished.
-			return
-		}
-
-		guard(syscall.Kill(-pgid, syscall.SIGINT), "send SIGINT to running process")
-	}
+	return proc
 }

--- a/tools/lib/cmd/update.go
+++ b/tools/lib/cmd/update.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -22,14 +20,13 @@ var updateCmd = &cobra.Command{
 
 		// TODO: include go.sum in generated hash.
 
-		compiler := exec.CommandContext(cmd.Context(), "go", //nolint:gosec // Input is not dynamically provided by end-user.
-			"install",
-			"-ldflags", "-X main.toolsHash="+curToolsHash,
-			filepath.FromSlash("./tools/cmd/"+config.CLIName),
-		)
-		compiler.Stderr = os.Stderr
-		compiler.Stdout = os.Stdout
-
-		guard(compiler.Run(), "execute `go install ...` command")
+		guard(runner.Run(cmd.Context(), Cmd{
+			Name: "go",
+			Args: []string{
+				"install",
+				"-ldflags", "-X main.toolsHash=" + curToolsHash,
+				filepath.FromSlash("./tools/cmd/" + config.CLIName),
+			},
+		}), "execute `go install ...` command")
 	},
 }


### PR DESCRIPTION
## Summary

First wave of the devctrl refactor spec. Introduces the `Runner` abstraction that all subprocess invocations route through, enabling `--dry-run` mode and testability.

- **New `Runner` and `Process` interfaces** in `tools/lib/cmd/runner.go` — `Cmd` struct describes a subprocess, `Runner.Run()` for synchronous execution, `Runner.Start()` for long-running processes
- **`ExecRunner`** — production implementation with proper env merging (explicit dedup, not platform-dependent last-wins), process group management, and SIGINT (fixes existing SIGKILL bug in `dopplerGoRun`)
- **`DryRunner`** — records all commands without executing; supports `ErrorFor` map for simulating failures in tests
- **`--dry-run` persistent flag** on `rootCmd` — prints commands that would run without executing them; skips `checkVersion()` in dry-run mode
- **All 10 command files refactored** to route through `Runner` instead of bare `exec.CommandContext`
- **`readDopplerVars`** routed through Runner — returns empty map in dry-run mode (defaults used, no side effects)
- **`triggerShutdown()`** replaces `beginShutdown` channel with `sync.Once`-guarded shutdown
- **`runner_test.go`** — 13 tests covering `Cmd.String()`, `DryRunner` recording, error simulation, command construction for check/generate/stop, env merging, and dry-run doppler behavior

## Files changed

| File | Change |
|------|--------|
| `tools/lib/cmd/runner.go` | **New** — `Cmd`, `Process`, `Runner`, `ExecRunner`, `DryRunner`, `mergeEnv`, `Cmd.String()` |
| `tools/lib/cmd/runner_test.go` | **New** — 13 tests |
| `tools/lib/cmd/root.go` | `--dry-run` flag, `triggerShutdown()`, runner initialization in `PersistentPreRun` |
| `tools/lib/cmd/check.go` | Thread runner through `checkGo`, `checkWeb`, `checkProto` |
| `tools/lib/cmd/generate.go` | Thread runner through all generate functions |
| `tools/lib/cmd/test.go` | Thread runner; `runE2ETest` returns `Process` instead of `func()` |
| `tools/lib/cmd/run.go` | Thread runner; `dopplerGoRun` returns `Process`; SIGKILL→SIGINT fix |
| `tools/lib/cmd/stop.go` | Thread runner; hardcode description string |
| `tools/lib/cmd/install.go` | Thread runner through `installWithGolang`, `installWithHomebrew` |
| `tools/lib/cmd/update.go` | Thread runner |
| `tools/lib/cmd/migrate.go` | Thread runner for `migrateCreate`; `getDatabaseURL` now takes runner |
| `tools/lib/cmd/config.go` | `readDopplerVars` takes runner; dry-run returns empty map |

## Behavioral changes

1. **SIGKILL → SIGINT** — `dopplerGoRun` stop function now sends SIGINT (graceful) instead of SIGKILL (was a bug; comment said SIGINT but code sent SIGKILL)
2. **Env merging** — `ExecRunner` explicitly deduplicates env vars by key instead of relying on platform behavior
3. **Log output** — all subprocess invocations now log `[pubgolf-devctrl] exec: <command>` before running (with `dir:` and `env:` lines if set)

## Test plan

- [x] `go test ./tools/...` passes (13 tests)
- [x] `pubgolf-devctrl check go` passes (0 lint issues)
- [x] `pubgolf-devctrl --dry-run check go` — should print the golangci-lint command without executing
- [x] `pubgolf-devctrl --dry-run generate proto` — should print buf generate command without executing
- [x] `pubgolf-devctrl --dry-run run bg` — should print doppler/docker-compose command without executing
- [x] `pubgolf-devctrl check go` still works identically (real execution path unchanged)
- [ ] `pubgolf-devctrl run api` still starts the server correctly

## Merge notes

- This is **Plan 01** — no dependencies on other plans
- Plans 02 (env provider), 03 (worktree identity), and 05 (error handling) depend on this PR
- Backward-compatible: no external behavior changes except the new `--dry-run` flag and improved log output
- After merge, run `pubgolf-devctrl update` to rebuild the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)