### PR TITLE
chore(deps): bump dev tool versions for Go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11
+          version: v2.11.4
           args: ./tools/...
       - name: Test
         run: go test ./tools/lib/...
@@ -84,7 +84,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11
+          version: v2.11.4
           args: ./api/...
       - name: Test
         run: go test ./api/...

--- a/api/internal/lib/models/scoringcategory_test.go
+++ b/api/internal/lib/models/scoringcategory_test.go
@@ -160,8 +160,7 @@ func TestNullScoringCategory_Scan(t *testing.T) {
 
 		rows, err := tx.QueryContext(ctx, "SELECT value FROM enum_scoring_categories")
 		require.NoError(t, err)
-
-		defer rows.Close()
+		t.Cleanup(func() { rows.Close() })
 
 		for rows.Next() {
 			var s string

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -10,12 +10,12 @@ import (
 )
 
 var goTools = map[string]string{
-	"migrate":       "github.com/golang-migrate/migrate/v4/cmd/migrate@v4.17.0",
-	"sqlc":          "github.com/sqlc-dev/sqlc/cmd/sqlc@v1.24.0",
-	"mockery":       "github.com/vektra/mockery/v2@v2.42.2",
-	"ifacemaker":    "github.com/vburenin/ifacemaker@v1.2.1",
-	"enumer":        "github.com/dmarkham/enumer@v1.5.9",
-	"golangci-lint": "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3",
+	"migrate":       "github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1",
+	"sqlc":          "github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0",
+	"mockery":       "github.com/vektra/mockery/v2@v2.53.6",
+	"ifacemaker":    "github.com/vburenin/ifacemaker@v1.3.0",
+	"enumer":        "github.com/dmarkham/enumer@v1.6.3",
+	"golangci-lint": "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4",
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- Bump all Go dev tool versions to latest releases compatible with Go 1.26 (mockery, enumer, migrate, sqlc, ifacemaker, golangci-lint)
- Pin CI golangci-lint to v2.11.4 to match local install, preventing lint discrepancies
- Fix `sqlclosecheck` violation in `scoringcategory_test.go` exposed by the linter upgrade

## Test plan
- [x] `pubgolf-devctrl install` succeeds with all bumped versions
- [x] `pubgolf-devctrl check go` passes clean (0 issues)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)