### PR TITLE
Wave 2 / Plan 05: Classified error handling with distinct exit codes

### DIFF
--- a/tools/lib/cmd/check.go
+++ b/tools/lib/cmd/check.go
@@ -16,8 +16,8 @@ func init() {
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Run all linting and static analysis sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args, checkGoCmd, checkWebCmd, checkProtoCmd)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(runPar(cmd.Context(), runner, checkGo, checkWeb, checkProto))
 	},
 }
 
@@ -25,7 +25,7 @@ var checkGoCmd = &cobra.Command{
 	Use:   "go",
 	Short: "Run golangci-lint on Go code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkGo(cmd.Context(), runner), "execute `golangci-lint run` command")
+		classifyAndExit(checkGo(cmd.Context(), runner))
 	},
 }
 
@@ -45,7 +45,7 @@ var checkWebCmd = &cobra.Command{
 	Use:   "web",
 	Short: "Run ESLint, Prettier, and svelte-check on web code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkWeb(cmd.Context(), runner), "execute web lint commands")
+		classifyAndExit(checkWeb(cmd.Context(), runner))
 	},
 }
 
@@ -75,7 +75,7 @@ var checkProtoCmd = &cobra.Command{
 	Use:   "proto",
 	Short: "Run buf lint and format check on proto files",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkProto(cmd.Context(), runner), "execute proto lint commands")
+		classifyAndExit(checkProto(cmd.Context(), runner))
 	},
 }
 

--- a/tools/lib/cmd/config.go
+++ b/tools/lib/cmd/config.go
@@ -100,7 +100,7 @@ func getDatabaseURL(ctx context.Context, ep EnvProvider, driver DBDriver, projec
 // keys (with the configured prefix stripped).
 func readEnvVars(ctx context.Context, ep EnvProvider, project, env, prefix string, vars []string) map[string]string {
 	envSlice, err := ep.Env(ctx, project, env)
-	guard(err, "fetch environment variables")
+	classifyAndExit(fmtErr(err, "fetch environment variables"))
 
 	// Build a lookup from the returned KEY=VALUE pairs.
 	envMap := make(map[string]string, len(envSlice))

--- a/tools/lib/cmd/errors.go
+++ b/tools/lib/cmd/errors.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// Exit codes for classifyAndExit.
+const (
+	// ExitCodeTestFailure indicates a code/test/lint failure (exit 1).
+	ExitCodeTestFailure = 1
+	// ExitCodeInfraFailure indicates an infrastructure failure (exit 2).
+	ExitCodeInfraFailure = 2
+)
+
+// infraPatterns are known stderr substrings that indicate infrastructure failures
+// rather than code/test problems.
+var infraPatterns = []string{
+	"address already in use",
+	"cannot connect to the docker daemon",
+	"connection refused",
+	"permission denied",
+	"no such host",
+	"container exited with code 137", // OOM killed
+}
+
+// isInfraError checks whether an error message matches known infrastructure failure patterns.
+func isInfraError(err error) bool {
+	msg := strings.ToLower(err.Error())
+
+	for _, p := range infraPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// classifyAndExit logs the error with classification and exits with the appropriate code.
+// Exit code 1 = code/test failure. Exit code 2 = infrastructure failure.
+func classifyAndExit(err error) {
+	if err == nil {
+		return
+	}
+
+	if isInfraError(err) {
+		log.Printf("ERROR: Infrastructure failure\n  %s\n  This is not a code issue.", err)
+		os.Exit(ExitCodeInfraFailure)
+	}
+
+	log.Printf("ERROR: %s", err)
+	os.Exit(ExitCodeTestFailure)
+}

--- a/tools/lib/cmd/errors_test.go
+++ b/tools/lib/cmd/errors_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInfraError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "address already in use",
+			err:  fmt.Errorf("listen tcp :5432: bind: address already in use: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "docker daemon unavailable",
+			err:  fmt.Errorf("Cannot connect to the Docker daemon at unix:///var/run/docker.sock: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  fmt.Errorf("dial tcp 127.0.0.1:5432: connection refused: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  fmt.Errorf("open /etc/secrets: permission denied: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "no such host",
+			err:  fmt.Errorf("dial tcp: lookup db.example.com: no such host: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "OOM killed container",
+			err:  fmt.Errorf("container exited with code 137: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "case insensitive match",
+			err:  fmt.Errorf("ADDRESS ALREADY IN USE: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "test failure is not infra",
+			err:  fmt.Errorf("exit status 1: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "lint failure is not infra",
+			err:  fmt.Errorf("run golangci-lint cmd: exit status 1: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "compilation error is not infra",
+			err:  fmt.Errorf("cannot find package foo: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "generic error is not infra",
+			err:  fmt.Errorf("something went wrong: %w", errSimulated),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isInfraError(tt.err))
+		})
+	}
+}

--- a/tools/lib/cmd/generate.go
+++ b/tools/lib/cmd/generate.go
@@ -28,13 +28,15 @@ func init() {
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Run all code generation sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args,
-			generateProtoCmd,
-			generateSQLcCmd,
-			generateEnumCmd,
-		)
-		generateMockCmd.Run(cmd, args)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(runPar(cmd.Context(), runner,
+			generateProto,
+			generateSQLc,
+			func(ctx context.Context, r Runner) error {
+				return generateEnum(ctx, r, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models"))
+			},
+		))
+		classifyAndExit(generateAllMocks(cmd.Context(), runner))
 	},
 }
 
@@ -43,9 +45,9 @@ var generateProtoCmd = &cobra.Command{
 	Short: "Generate protobuf and gRPC code",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-		guard(generateProto(cmd.Context(), runner), "execute `buf ...` command")
+		classifyAndExit(generateProto(cmd.Context(), runner))
 
 		if !watchFlag {
 			return
@@ -79,9 +81,9 @@ var generateSQLcCmd = &cobra.Command{
 	Short: "Generate SQLc queries and data holders",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-		guard(generateSQLc(cmd.Context(), runner), "execute `sqlc ...` command")
+		classifyAndExit(generateSQLc(cmd.Context(), runner))
 
 		if !watchFlag {
 			return
@@ -114,7 +116,7 @@ var generateEnumCmd = &cobra.Command{
 	Use:   "enum",
 	Short: "Generate enum stringers",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(generateEnum(cmd.Context(), runner, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")), "execute `enumer ...` command for ")
+		classifyAndExit(generateEnum(cmd.Context(), runner, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")))
 	},
 }
 
@@ -133,24 +135,50 @@ func generateEnum(ctx context.Context, r Runner, typ, pkg string) error {
 var generateMockCmd = &cobra.Command{
 	Use:   "mock",
 	Short: "Generate IO clients' (DAO and SMS) interfaces and mocks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args,
-			generateDBCMockCmd,
-			generateSMSMockCmd,
-		)
-		// generateDAOMockCmd must be called after generateDBCMockCmd.
-		generateDAOMockCmd.Run(cmd, args)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(generateAllMocks(cmd.Context(), runner))
 	},
+}
+
+func generateAllMocks(ctx context.Context, r Runner) error {
+	// DBC and SMS mocks can run in parallel.
+	err := runPar(ctx, r,
+		func(ctx context.Context, r Runner) error {
+			return generateMock(ctx, r, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/"))
+		},
+		func(ctx context.Context, r Runner) error {
+			return generateInterfaceAndMock(ctx, r, smsConfig)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// generateDAOMock must be called after generateDBCMock.
+	return generateInterfaceAndMock(ctx, r, daoConfig)
+}
+
+var daoConfig = mockConfig{
+	targetStruct: "Queries",
+	ifaceName:    "QueryProvider",
+	ifaceComment: "QueryProvider describes all of the queries exposed by the DAO, to allow for testing mocks.",
+	genDir:       filepath.FromSlash("api/internal/lib/dao/"),
+	pkgName:      "dao",
+}
+
+var smsConfig = mockConfig{
+	targetStruct: "Client",
+	ifaceName:    "Messenger",
+	ifaceComment: "Messenger describes all of the operations exposed by the SMS client, to allow for testing mocks.",
+	genDir:       filepath.FromSlash("api/internal/lib/sms/"),
+	pkgName:      "sms",
 }
 
 var generateDBCMockCmd = &cobra.Command{
 	Use:   "dbc",
 	Short: "Generate DBC mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateMock(cmd.Context(), runner, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")),
-			"generate mock DBC",
-		)
+		classifyAndExit(generateMock(cmd.Context(), runner, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")))
 	},
 }
 
@@ -158,16 +186,7 @@ var generateDAOMockCmd = &cobra.Command{
 	Use:   "dao",
 	Short: "Generate DAO interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
-				targetStruct: "Queries",
-				ifaceName:    "QueryProvider",
-				ifaceComment: "QueryProvider describes all of the queries exposed by the DAO, to allow for testing mocks.",
-				genDir:       filepath.FromSlash("api/internal/lib/dao/"),
-				pkgName:      "dao",
-			}),
-			"generate mock DAO",
-		)
+		classifyAndExit(generateInterfaceAndMock(cmd.Context(), runner, daoConfig))
 	},
 }
 
@@ -175,16 +194,7 @@ var generateSMSMockCmd = &cobra.Command{
 	Use:   "sms",
 	Short: "Generate SMS client interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
-				targetStruct: "Client",
-				ifaceName:    "Messenger",
-				ifaceComment: "Messenger describes all of the operations exposed by the SMS client, to allow for testing mocks.",
-				genDir:       filepath.FromSlash("api/internal/lib/sms/"),
-				pkgName:      "sms",
-			}),
-			"generate mock SMS Client",
-		)
+		classifyAndExit(generateInterfaceAndMock(cmd.Context(), runner, smsConfig))
 	},
 }
 

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -30,15 +30,28 @@ func init() {
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Run all tool installation sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		installers := []*cobra.Command{
-			installDopplerCmd,
-			installBufCmd,
+	Run: func(cmd *cobra.Command, _ []string) {
+		fns := []func(context.Context, Runner) error{
+			func(ctx context.Context, r Runner) error {
+				err := installWithHomebrew(ctx, r, "gnupg")
+				if err != nil {
+					return err
+				}
+
+				return installWithHomebrew(ctx, r, "dopplerhq/cli/doppler")
+			},
+			func(ctx context.Context, r Runner) error {
+				return installWithHomebrew(ctx, r, "bufbuild/buf/buf")
+			},
 		}
 
-		installers = append(installers, generateGoInstallers()...)
+		for _, pkg := range goTools {
+			fns = append(fns, func(ctx context.Context, r Runner) error {
+				return installWithGolang(ctx, r, pkg)
+			})
+		}
 
-		runPar(cmd, args, installers...)
+		classifyAndExit(runPar(cmd.Context(), runner, fns...))
 	},
 }
 
@@ -50,7 +63,7 @@ func generateGoInstallers() []*cobra.Command {
 			Use:   n,
 			Short: fmt.Sprintf("Install the %q CLI tool", n),
 			Run: func(cmd *cobra.Command, _ []string) {
-				guard(installWithGolang(cmd.Context(), runner, v), "install Go tool")
+				classifyAndExit(installWithGolang(cmd.Context(), runner, v))
 			},
 		})
 	}
@@ -62,8 +75,8 @@ var installDopplerCmd = &cobra.Command{
 	Use:   "doppler",
 	Short: "Install the `doppler` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(installWithHomebrew(cmd.Context(), runner, "gnupg"), "install gnupg")
-		guard(installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler"), "install doppler")
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "gnupg"))
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler"))
 	},
 }
 
@@ -71,7 +84,7 @@ var installBufCmd = &cobra.Command{
 	Use:   "buf",
 	Short: "Install the `buf` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf"), "install buf")
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf"))
 	},
 }
 

--- a/tools/lib/cmd/migrate.go
+++ b/tools/lib/cmd/migrate.go
@@ -47,14 +47,14 @@ var migrateUpCmd = &cobra.Command{
 		m := getMigrator(cmd.Context())
 
 		if len(args) < 1 {
-			guard(m.Up(), "run up migration")
+			classifyAndExit(fmtErr(m.Up(), "run up migration"))
 
 			return
 		}
 
 		steps, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse number of migration steps")
-		guard(m.Steps(int(steps)), "run up migration")
+		classifyAndExit(fmtErr(err, "parse number of migration steps"))
+		classifyAndExit(fmtErr(m.Steps(int(steps)), "run up migration"))
 	},
 }
 
@@ -66,19 +66,19 @@ var migrateDownCmd = &cobra.Command{
 		m := getMigrator(cmd.Context())
 
 		if len(args) < 1 {
-			guard(m.Down(), "run up migration")
+			classifyAndExit(fmtErr(m.Down(), "run down migration"))
 
 			return
 		}
 
 		steps, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse number of migration steps")
+		classifyAndExit(fmtErr(err, "parse number of migration steps"))
 
 		if steps > 0 {
 			steps = -steps
 		}
 
-		guard(m.Steps(int(steps)), "run up migration")
+		classifyAndExit(fmtErr(m.Steps(int(steps)), "run down migration"))
 	},
 }
 
@@ -87,18 +87,21 @@ var migrateCreateCmd = &cobra.Command{
 	Short: "Create new migration files",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		migrateCreate(cmd.Context(), runner, args[0])
+		classifyAndExit(migrateCreate(cmd.Context(), runner, args[0]))
 	},
 }
 
-func migrateCreate(ctx context.Context, r Runner, name string) {
+func migrateCreate(ctx context.Context, r Runner, name string) error {
 	var migratorContent bytes.Buffer
 
-	guard(r.Run(ctx, Cmd{
+	err := r.Run(ctx, Cmd{
 		Name:   "migrate",
 		Args:   []string{"create", "-seq", "-ext", "sql", "-dir", migrationDirectory, name},
 		Stderr: io.MultiWriter(os.Stderr, &migratorContent),
-	}), "execute `migrate ...` command")
+	})
+	if err != nil {
+		return fmtErr(err, "execute `migrate ...` command")
+	}
 
 	outLines := strings.Split(migratorContent.String(), "\n")
 	foundFiles := false
@@ -112,17 +115,23 @@ func migrateCreate(ctx context.Context, r Runner, name string) {
 		foundFiles = true
 
 		f, err := os.OpenFile(name, os.O_RDWR, 0o644)
-		guard(err, "open migration file to add boilerplate")
+		if err != nil {
+			return fmtErr(err, "open migration file to add boilerplate")
+		}
 
 		defer f.Close()
 
 		_, err = f.WriteString("BEGIN;\n\n-- Migration logic goes here...\n\nCOMMIT;\n")
-		guard(err, "write boilerplate to migration file")
+		if err != nil {
+			return fmtErr(err, "write boilerplate to migration file")
+		}
 	}
 
 	if !foundFiles {
 		log.Println("WARNING: no migration files found in migrate output")
 	}
+
+	return nil
 }
 
 var migrateFixCmd = &cobra.Command{
@@ -132,27 +141,27 @@ var migrateFixCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		dbURL := getDatabaseURL(cmd.Context(), envProvider, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, false)
 		db, err := sql.Open(config.DBDriver.driverString(false), dbURL)
-		guard(err, "open DB connection")
+		classifyAndExit(fmtErr(err, "open DB connection"))
 
 		version, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse desired version")
+		classifyAndExit(fmtErr(err, "parse desired version"))
 
 		if version < 1 {
 			_, err = db.Exec("DROP TABLE IF EXISTS schema_migrations;")
-			guard(err, "drop schema_migrations table")
+			classifyAndExit(fmtErr(err, "drop schema_migrations table"))
 
 			return
 		}
 
 		_, err = db.Exec("UPDATE schema_migrations SET version = $1, dirty = false;", version)
-		guard(err, "reset schema_migrations table")
+		classifyAndExit(fmtErr(err, "reset schema_migrations table"))
 	},
 }
 
 func getMigrator(ctx context.Context) *migrate.Migrate {
 	dbURL := getDatabaseURL(ctx, envProvider, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, true)
 	m, err := migrate.New(migrationSource, dbURL)
-	guard(err, "construct DB migrator")
+	classifyAndExit(fmtErr(err, "construct DB migrator"))
 
 	return m
 }

--- a/tools/lib/cmd/root.go
+++ b/tools/lib/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -134,7 +135,7 @@ func init() {
 
 func checkVersion() {
 	curToolsHash, err := dirhash.HashDir(filepath.Join(projectRoot, "tools"), "", dirhash.DefaultHash)
-	guard(err, "hash tools dir")
+	classifyAndExit(fmtErr(err, "hash tools dir"))
 
 	if installedToolsHash != curToolsHash {
 		log.Printf(`The installed version of %[1]s is out of date. Run the following to update:
@@ -145,29 +146,36 @@ func checkVersion() {
 	}
 }
 
-// guard logs and exits on error.
-func guard(err error, msg string) {
-	if err != nil {
-		log.Fatalf("%s: %v", msg, err.Error())
-	}
-}
+// runPar executes all of the specified functions in parallel and returns a joined error.
+func runPar(ctx context.Context, r Runner, fns ...func(context.Context, Runner) error) error {
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
 
-// runPar executes all of the specified commands in parallel.
-func runPar(cmd *cobra.Command, args []string, commands ...*cobra.Command) {
-	var wg sync.WaitGroup
+	for _, fn := range fns {
+		wg.Add(1)
 
-	wg.Add(len(commands))
-
-	for _, c := range commands {
-		go func(cmd *cobra.Command, args []string, c *cobra.Command) {
+		go func(f func(context.Context, Runner) error) {
 			defer wg.Done()
 
-			log.Printf("Running `%s`...\n", c.Use)
-			c.Run(cmd, args)
-		}(cmd, args, c)
+			err := f(ctx, r)
+			if err == nil {
+				return
+			}
+
+			mu.Lock()
+
+			errs = append(errs, err)
+
+			mu.Unlock()
+		}(fn)
 	}
 
 	wg.Wait()
+
+	return errors.Join(errs...)
 }
 
 // ignoredDirPatterns lists directory names that file watchers should skip.
@@ -202,15 +210,15 @@ func watch(dir, label string, callback func(watcher.Event)) {
 				callback(ev)
 				log.Printf("Task '%s' completed.\n", label)
 			case err := <-w.Error:
-				guard(err, "watcher failed")
+				classifyAndExit(fmtErr(err, "watcher failed"))
 			case <-w.Closed:
 				return
 			}
 		}
 	}()
 
-	guard(w.AddRecursive(dir), "create watcher")
+	classifyAndExit(fmtErr(w.AddRecursive(dir), "create watcher"))
 	log.Printf("Watching '%s' for changes...\n", dir)
 
-	go guard(w.Start(100*time.Millisecond), "start watcher")
+	go classifyAndExit(fmtErr(w.Start(100*time.Millisecond), "start watcher"))
 }

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -23,10 +23,12 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run all server executables",
 	Run: func(cmd *cobra.Command, args []string) {
-		runAPIBgCmd.Run(cmd, args)
-		runPar(cmd, args,
-			runAPIServerCmd,
-		)
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
+			"api-db",
+		))
+
+		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
+		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
 	},
 }
 
@@ -43,10 +45,10 @@ var runAPIBgCmd = &cobra.Command{
 	Use:   "bg",
 	Short: "Run all supporting services for the API server",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
 			"api-db",
 			// "api-blob-storage",
-		), "execute `docker-compose up ...` command")
+		))
 	},
 }
 
@@ -54,8 +56,7 @@ var runAPIDatabaseCmd = &cobra.Command{
 	Use:   "api-db",
 	Short: "Run API server's DB instance",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName, "api-db"),
-			"execute `docker-compose up ...` command")
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName, "api-db"))
 	},
 }
 
@@ -96,7 +97,7 @@ func dockerRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg st
 
 func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
-	guard(err, "check '--watch' flag")
+	classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
 	// Start initial process
 	proc := startGoRun(cmd.Context(), r, ep, project, envCfg, bin, args)
@@ -126,7 +127,7 @@ func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCf
 
 func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process { //nolint:ireturn // Returns Process interface by design.
 	env, err := ep.Env(ctx, project, envCfg)
-	guard(err, "fetch go run environment")
+	classifyAndExit(fmtErr(err, "fetch go run environment"))
 
 	allArgs := append([]string{"run", bin}, args...)
 
@@ -137,7 +138,7 @@ func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, 
 		Args: allArgs,
 		Env:  env,
 	})
-	guard(startErr, "execute `go run ...` command")
+	classifyAndExit(fmtErr(startErr, "execute `go run ...` command"))
 
 	return proc
 }

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,4 +149,38 @@ func splitEnvVar(s string) [2]string {
 	}
 
 	return [2]string{s[:i], s[i+1:]}
+}
+
+var (
+	errRunParA = fmt.Errorf("error A: %w", errSimulated)
+	errRunParB = fmt.Errorf("error B: %w", errSimulated)
+)
+
+func TestRunParCollectsErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dr := &DryRunner{}
+
+	err := runPar(ctx, dr,
+		func(_ context.Context, _ Runner) error { return errRunParA },
+		func(_ context.Context, _ Runner) error { return nil },
+		func(_ context.Context, _ Runner) error { return errRunParB },
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errRunParA)
+	require.ErrorIs(t, err, errRunParB)
+}
+
+func TestRunParNoErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dr := &DryRunner{}
+
+	err := runPar(ctx, dr,
+		func(_ context.Context, _ Runner) error { return nil },
+		func(_ context.Context, _ Runner) error { return nil },
+	)
+	assert.NoError(t, err)
 }

--- a/tools/lib/cmd/stop.go
+++ b/tools/lib/cmd/stop.go
@@ -15,8 +15,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop all background processes started with `devctrl run ...`",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerStop(cmd.Context(), runner),
-			"execute `docker-compose down ...` command")
+		classifyAndExit(dockerStop(cmd.Context(), runner))
 	},
 }
 

--- a/tools/lib/cmd/test.go
+++ b/tools/lib/cmd/test.go
@@ -30,16 +30,16 @@ var testCmd = &cobra.Command{
 		coverageFile := filepath.Join(coverageDir, "api.cover")
 
 		coverageFlag, err := cmd.Flags().GetBool("coverage")
-		guard(err, "check '--coverage' flag")
+		classifyAndExit(fmtErr(err, "check '--coverage' flag"))
 
 		verboseFlag, err := cmd.Flags().GetBool("verbose")
-		guard(err, "check '--verbose' flag")
+		classifyAndExit(fmtErr(err, "check '--verbose' flag"))
 
 		localFlag, err := cmd.Flags().GetBool("local")
-		guard(err, "check '--local' flag")
+		classifyAndExit(fmtErr(err, "check '--local' flag"))
 
 		env, envErr := envProvider.Env(cmd.Context(), config.ServerBinName, "test")
-		guard(envErr, "fetch test environment")
+		classifyAndExit(fmtErr(envErr, "fetch test environment"))
 
 		args := []string{"test", filepath.FromSlash("./api/...")}
 
@@ -54,8 +54,8 @@ var testCmd = &cobra.Command{
 		if coverageFlag {
 			args = append(args, "-coverprofile", coverageFile)
 
-			guard(os.RemoveAll(coverageDir), "clean old output dir")
-			guard(os.MkdirAll(coverageDir, 0o755), "make new output dir")
+			classifyAndExit(fmtErr(os.RemoveAll(coverageDir), "clean old output dir"))
+			classifyAndExit(fmtErr(os.MkdirAll(coverageDir, 0o755), "make new output dir"))
 		}
 
 		err = runner.Run(cmd.Context(), Cmd{
@@ -64,18 +64,18 @@ var testCmd = &cobra.Command{
 			Env:  env,
 		})
 		if err != nil {
-			// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+			// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 			exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 			if !ok || exitErr.ExitCode() != 1 {
-				guard(err, "execute `go test ...` command")
+				classifyAndExit(fmtErr(err, "execute `go test ...` command"))
 			}
 		}
 
 		if coverageFlag {
-			guard(runner.Run(cmd.Context(), Cmd{
+			classifyAndExit(fmtErr(runner.Run(cmd.Context(), Cmd{
 				Name: "go",
 				Args: []string{"tool", "cover", "-html", coverageFile},
-			}), "execute `go tool cover ...` command")
+			}), "execute `go tool cover ...` command"))
 		}
 	},
 }
@@ -85,10 +85,10 @@ var testE2ECmd = &cobra.Command{
 	Short: "Run all automated e2e tests",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
 		localFlag, err := cmd.Flags().GetBool("local")
-		guard(err, "check '--local' flag")
+		classifyAndExit(fmtErr(err, "check '--local' flag"))
 
 		// Start initial process.
 		proc := runE2ETest(cmd.Context(), runner, envProvider, !watchFlag, localFlag)
@@ -110,7 +110,7 @@ var testE2ECmd = &cobra.Command{
 
 func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, localOnly bool) Process { //nolint:ireturn // Returns Process interface by design.
 	env, err := ep.Env(ctx, config.ServerBinName, "test")
-	guard(err, "fetch e2e test environment")
+	classifyAndExit(fmtErr(err, "fetch e2e test environment"))
 
 	args := []string{
 		"test",
@@ -135,10 +135,10 @@ func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, local
 		Env:  env,
 	})
 	if startErr != nil {
-		// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+		// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 		exitErr, ok := startErr.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 		if !ok || exitErr.ExitCode() != 1 {
-			guard(startErr, "execute `go test ...` command")
+			classifyAndExit(fmtErr(startErr, "execute `go test ...` command"))
 		}
 	}
 
@@ -148,10 +148,10 @@ func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, local
 
 			waitErr := proc.Wait()
 			if waitErr != nil {
-				// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+				// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 				exitErr, ok := waitErr.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 				if !ok || exitErr.ExitCode() != 1 {
-					guard(waitErr, "execute `go test ...` command")
+					classifyAndExit(fmtErr(waitErr, "execute `go test ...` command"))
 				}
 			}
 		}()

--- a/tools/lib/cmd/update.go
+++ b/tools/lib/cmd/update.go
@@ -16,17 +16,17 @@ var updateCmd = &cobra.Command{
 	Short: "Compiles the latest changes into the devctl binary",
 	Run: func(cmd *cobra.Command, _ []string) {
 		curToolsHash, err := dirhash.HashDir("tools", "", dirhash.DefaultHash)
-		guard(err, "hash tools dir")
+		classifyAndExit(fmtErr(err, "hash tools dir"))
 
 		// TODO: include go.sum in generated hash.
 
-		guard(runner.Run(cmd.Context(), Cmd{
+		classifyAndExit(fmtErr(runner.Run(cmd.Context(), Cmd{
 			Name: "go",
 			Args: []string{
 				"install",
 				"-ldflags", "-X main.toolsHash=" + curToolsHash,
 				filepath.FromSlash("./tools/cmd/" + config.CLIName),
 			},
-		}), "execute `go install ...` command")
+		}), "execute `go install ...` command"))
 	},
 }


### PR DESCRIPTION
## Summary

- Replace `guard`/`log.Fatalf` with `classifyAndExit` for agent-oriented error handling — exit code 1 for code/test failures, exit code 2 for infrastructure failures (port conflicts, Docker daemon down, OOM, etc.)
- Refactor `runPar` from dispatching cobra commands to accepting error-returning functions with `errors.Join` aggregation
- Remove the `guard` function entirely; all cobra `Run` closures now use `classifyAndExit`
- Add `isInfraError` pattern matching for known infrastructure failure signatures

## Test plan
- [x] `go test ./tools/...` passes (64 tests, including new error classification + runPar tests)
- [x] `pubgolf-devctrl check go` passes (0 lint issues)
- [ ] Manual: stop Docker, run a command → verify exit code 2 and clear error message
- [ ] Manual: introduce a lint error → verify exit code 1

## Merge instructions
Merge via GitHub once CI is green and review is approved. This is part of Wave 2 of the devctrl worktree robustness refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)