### PR TITLE
add(tools): error classification with classifyAndExit [plan-05/wave-2a]

### DIFF
--- a/tools/lib/cmd/config.go
+++ b/tools/lib/cmd/config.go
@@ -100,7 +100,7 @@ func getDatabaseURL(ctx context.Context, ep EnvProvider, driver DBDriver, projec
 // keys (with the configured prefix stripped).
 func readEnvVars(ctx context.Context, ep EnvProvider, project, env, prefix string, vars []string) map[string]string {
 	envSlice, err := ep.Env(ctx, project, env)
-	guard(err, "fetch environment variables")
+	classifyAndExit(fmtErr(err, "fetch environment variables"))
 
 	// Build a lookup from the returned KEY=VALUE pairs.
 	envMap := make(map[string]string, len(envSlice))

--- a/tools/lib/cmd/errors.go
+++ b/tools/lib/cmd/errors.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// Exit codes for classifyAndExit.
+const (
+	// ExitCodeTestFailure indicates a code/test/lint failure (exit 1).
+	ExitCodeTestFailure = 1
+	// ExitCodeInfraFailure indicates an infrastructure failure (exit 2).
+	ExitCodeInfraFailure = 2
+)
+
+// infraPatterns are known stderr substrings that indicate infrastructure failures
+// rather than code/test problems.
+var infraPatterns = []string{
+	"address already in use",
+	"cannot connect to the docker daemon",
+	"connection refused",
+	"permission denied",
+	"no such host",
+	"container exited with code 137", // OOM killed
+}
+
+// isInfraError checks whether an error message matches known infrastructure failure patterns.
+func isInfraError(err error) bool {
+	msg := strings.ToLower(err.Error())
+
+	for _, p := range infraPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// classifyAndExit logs the error with classification and exits with the appropriate code.
+// Exit code 1 = code/test failure. Exit code 2 = infrastructure failure.
+func classifyAndExit(err error) {
+	if err == nil {
+		return
+	}
+
+	if isInfraError(err) {
+		log.Printf("ERROR: Infrastructure failure\n  %s\n  This is not a code issue.", err)
+		os.Exit(ExitCodeInfraFailure)
+	}
+
+	log.Printf("ERROR: %s", err)
+	os.Exit(ExitCodeTestFailure)
+}

--- a/tools/lib/cmd/errors_test.go
+++ b/tools/lib/cmd/errors_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInfraError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "address already in use",
+			err:  fmt.Errorf("listen tcp :5432: bind: address already in use: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "docker daemon unavailable",
+			err:  fmt.Errorf("Cannot connect to the Docker daemon at unix:///var/run/docker.sock: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  fmt.Errorf("dial tcp 127.0.0.1:5432: connection refused: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  fmt.Errorf("open /etc/secrets: permission denied: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "no such host",
+			err:  fmt.Errorf("dial tcp: lookup db.example.com: no such host: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "OOM killed container",
+			err:  fmt.Errorf("container exited with code 137: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "case insensitive match",
+			err:  fmt.Errorf("ADDRESS ALREADY IN USE: %w", errSimulated),
+			want: true,
+		},
+		{
+			name: "test failure is not infra",
+			err:  fmt.Errorf("exit status 1: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "lint failure is not infra",
+			err:  fmt.Errorf("run golangci-lint cmd: exit status 1: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "compilation error is not infra",
+			err:  fmt.Errorf("cannot find package foo: %w", errSimulated),
+			want: false,
+		},
+		{
+			name: "generic error is not infra",
+			err:  fmt.Errorf("something went wrong: %w", errSimulated),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isInfraError(tt.err))
+		})
+	}
+}

--- a/tools/lib/cmd/stop.go
+++ b/tools/lib/cmd/stop.go
@@ -15,8 +15,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop all background processes started with `devctrl run ...`",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerStop(cmd.Context(), runner),
-			"execute `docker-compose down ...` command")
+		classifyAndExit(dockerStop(cmd.Context(), runner))
 	},
 }
 

--- a/tools/lib/cmd/test.go
+++ b/tools/lib/cmd/test.go
@@ -30,16 +30,16 @@ var testCmd = &cobra.Command{
 		coverageFile := filepath.Join(coverageDir, "api.cover")
 
 		coverageFlag, err := cmd.Flags().GetBool("coverage")
-		guard(err, "check '--coverage' flag")
+		classifyAndExit(fmtErr(err, "check '--coverage' flag"))
 
 		verboseFlag, err := cmd.Flags().GetBool("verbose")
-		guard(err, "check '--verbose' flag")
+		classifyAndExit(fmtErr(err, "check '--verbose' flag"))
 
 		localFlag, err := cmd.Flags().GetBool("local")
-		guard(err, "check '--local' flag")
+		classifyAndExit(fmtErr(err, "check '--local' flag"))
 
 		env, envErr := envProvider.Env(cmd.Context(), config.ServerBinName, "test")
-		guard(envErr, "fetch test environment")
+		classifyAndExit(fmtErr(envErr, "fetch test environment"))
 
 		args := []string{"test", filepath.FromSlash("./api/...")}
 
@@ -54,8 +54,8 @@ var testCmd = &cobra.Command{
 		if coverageFlag {
 			args = append(args, "-coverprofile", coverageFile)
 
-			guard(os.RemoveAll(coverageDir), "clean old output dir")
-			guard(os.MkdirAll(coverageDir, 0o755), "make new output dir")
+			classifyAndExit(fmtErr(os.RemoveAll(coverageDir), "clean old output dir"))
+			classifyAndExit(fmtErr(os.MkdirAll(coverageDir, 0o755), "make new output dir"))
 		}
 
 		err = runner.Run(cmd.Context(), Cmd{
@@ -64,18 +64,18 @@ var testCmd = &cobra.Command{
 			Env:  env,
 		})
 		if err != nil {
-			// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+			// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 			exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 			if !ok || exitErr.ExitCode() != 1 {
-				guard(err, "execute `go test ...` command")
+				classifyAndExit(fmtErr(err, "execute `go test ...` command"))
 			}
 		}
 
 		if coverageFlag {
-			guard(runner.Run(cmd.Context(), Cmd{
+			classifyAndExit(fmtErr(runner.Run(cmd.Context(), Cmd{
 				Name: "go",
 				Args: []string{"tool", "cover", "-html", coverageFile},
-			}), "execute `go tool cover ...` command")
+			}), "execute `go tool cover ...` command"))
 		}
 	},
 }
@@ -85,10 +85,10 @@ var testE2ECmd = &cobra.Command{
 	Short: "Run all automated e2e tests",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
 		localFlag, err := cmd.Flags().GetBool("local")
-		guard(err, "check '--local' flag")
+		classifyAndExit(fmtErr(err, "check '--local' flag"))
 
 		// Start initial process.
 		proc := runE2ETest(cmd.Context(), runner, envProvider, !watchFlag, localFlag)
@@ -110,7 +110,7 @@ var testE2ECmd = &cobra.Command{
 
 func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, localOnly bool) Process { //nolint:ireturn // Returns Process interface by design.
 	env, err := ep.Env(ctx, config.ServerBinName, "test")
-	guard(err, "fetch e2e test environment")
+	classifyAndExit(fmtErr(err, "fetch e2e test environment"))
 
 	args := []string{
 		"test",
@@ -135,10 +135,10 @@ func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, local
 		Env:  env,
 	})
 	if startErr != nil {
-		// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+		// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 		exitErr, ok := startErr.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 		if !ok || exitErr.ExitCode() != 1 {
-			guard(startErr, "execute `go test ...` command")
+			classifyAndExit(fmtErr(startErr, "execute `go test ...` command"))
 		}
 	}
 
@@ -148,10 +148,10 @@ func runE2ETest(ctx context.Context, r Runner, ep EnvProvider, stopOnExit, local
 
 			waitErr := proc.Wait()
 			if waitErr != nil {
-				// Panic on error, unless the exit code is 1, in which case it just means our test suite failed.
+				// Allow exit code 1 through — it means the test suite failed (not infrastructure).
 				exitErr, ok := waitErr.(*exec.ExitError) //nolint:errorlint // Casting to extract data.
 				if !ok || exitErr.ExitCode() != 1 {
-					guard(waitErr, "execute `go test ...` command")
+					classifyAndExit(fmtErr(waitErr, "execute `go test ...` command"))
 				}
 			}
 		}()

--- a/tools/lib/cmd/update.go
+++ b/tools/lib/cmd/update.go
@@ -16,17 +16,17 @@ var updateCmd = &cobra.Command{
 	Short: "Compiles the latest changes into the devctl binary",
 	Run: func(cmd *cobra.Command, _ []string) {
 		curToolsHash, err := dirhash.HashDir("tools", "", dirhash.DefaultHash)
-		guard(err, "hash tools dir")
+		classifyAndExit(fmtErr(err, "hash tools dir"))
 
 		// TODO: include go.sum in generated hash.
 
-		guard(runner.Run(cmd.Context(), Cmd{
+		classifyAndExit(fmtErr(runner.Run(cmd.Context(), Cmd{
 			Name: "go",
 			Args: []string{
 				"install",
 				"-ldflags", "-X main.toolsHash=" + curToolsHash,
 				filepath.FromSlash("./tools/cmd/" + config.CLIName),
 			},
-		}), "execute `go install ...` command")
+		}), "execute `go install ...` command"))
 	},
 }


### PR DESCRIPTION
## Summary
- Add `errors.go` with `classifyAndExit` and `isInfraError` for agent-oriented error handling (exit 1 = code/test, exit 2 = infra)
- Migrate direct `guard` → `classifyAndExit(fmtErr(...))` replacements in config, stop, test, and update commands
- `guard` is still present for the remaining commands (migrated in follow-up PR)

## Test plan
- [x] `go build ./tools/...` passes
- [x] `go test ./tools/lib/cmd/...` passes (70 tests)
- [ ] Verify exit code 1 on lint/test failure
- [ ] Verify exit code 2 on infra failure (e.g. Docker not running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)