### PR TITLE
add(tools): runPar refactor, guard migration, and CLAUDE.md [plan-05/wave-2b]

### DIFF
--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -1,0 +1,121 @@
+# tools/ — DevCtrl Conventions
+
+All devctrl source lives under `tools/lib/cmd/`. Each file maps to a top-level
+command group (`check.go` → `devctrl check`, `generate.go` → `devctrl generate`, etc.).
+The entry point in `tools/cmd/pubgolf-devctrl/main.go` just calls `cmd.Execute()`.
+
+## Adding a New Command
+
+1. Create a file named after the command group (e.g. `deploy.go`).
+2. Register in `init()` — add subcommands to the parent, then the parent to `rootCmd`.
+3. Cobra handler should be a thin wrapper that calls a testable function:
+
+```go
+func init() {
+    deployCmd.AddCommand(deployAPICmd)
+    rootCmd.AddCommand(deployCmd)
+}
+
+var deployCmd = &cobra.Command{
+    Use:   "deploy",
+    Short: "Deploy all services",
+    Run: func(cmd *cobra.Command, _ []string) {
+        classifyAndExit(deployAll(cmd.Context(), runner))
+    },
+}
+
+// deployAll is the testable handler — accepts Runner, returns error.
+func deployAll(ctx context.Context, r Runner) error {
+    err := r.Run(ctx, Cmd{Name: "kubectl", Args: []string{"apply", "-f", "..."}})
+    if err != nil {
+        return fmtErr(err, "run kubectl apply cmd")
+    }
+
+    return nil
+}
+```
+
+## Error Handling
+
+Two functions, always used together:
+- `fmtErr(err, "context message")` — wraps with context, nil-safe.
+- `classifyAndExit(err)` — logs and exits with code 1 (test/lint) or 2 (infra).
+
+Handlers **return errors**. Only the cobra `Run` wrapper calls `classifyAndExit`:
+
+```go
+// In handler (returns error):
+return fmtErr(err, "run buf lint cmd")
+
+// In cobra Run (exits):
+classifyAndExit(handlerFunc(cmd.Context(), runner))
+```
+
+Never call `log.Fatal`, `os.Exit`, or `panic` directly from handler functions.
+
+## Runner & Process
+
+All subprocess execution goes through the `Runner` interface:
+- `Runner.Run(ctx, Cmd)` — execute and wait.
+- `Runner.Start(ctx, Cmd)` — start a long-running process, returns `Process`.
+- `Process.Wait()` / `Process.Stop()` — lifecycle management.
+
+Production: `ExecRunner`. Tests/dry-run: `DryRunner` (records commands, injects errors).
+
+Handler functions always accept `Runner` as a parameter — never use the package-level
+`runner` directly in a handler. This enables testing with `DryRunner`.
+
+```go
+// Good: accepts Runner parameter
+func checkGo(ctx context.Context, r Runner) error { ... }
+
+// Bad: uses package global
+func checkGo(ctx context.Context) error { runner.Run(...) }
+```
+
+## EnvProvider
+
+Commands that need secrets accept `EnvProvider` as a parameter:
+- `DopplerProvider` — fetches from Doppler CLI.
+- `EnvFileProvider` — reads `.env.{config}` files.
+- `AutoProvider` — tries Doppler, falls back to env files.
+
+Same rule as Runner: pass as parameter, don't use the package global in handlers.
+
+## Parallel Execution
+
+Use `runPar` to run independent tasks concurrently. It collects all errors via
+`errors.Join` (not just the first):
+
+```go
+classifyAndExit(runPar(cmd.Context(), runner, checkGo, checkWeb, checkProto))
+```
+
+Each function passed to `runPar` must have the signature
+`func(context.Context, Runner) error`.
+
+## Testing
+
+- Use `DryRunner` to verify which commands a handler invokes:
+  ```go
+  dr := &DryRunner{}
+  err := deployAll(context.Background(), dr)
+  require.NoError(t, err)
+  require.Len(t, dr.Recorded, 1)
+  assert.Equal(t, "kubectl", dr.Recorded[0].Name)
+  ```
+- Use `DryRunner.ErrorFor` to simulate failures by command name.
+- Use `require.*` for preconditions, `assert.*` for result checks (testify).
+- All tests must call `t.Parallel()`.
+
+## Naming
+
+- Files: one per command group, named to match the cobra `Use` field.
+- Handler functions: `verbNoun` (e.g. `checkGo`, `generateProto`, `dockerRun`).
+- Cobra vars: `{group}Cmd`, `{group}{Sub}Cmd` (e.g. `checkCmd`, `checkGoCmd`).
+
+## nolint Annotations
+
+- `//nolint:ireturn` — on functions that return an interface by design (Runner, Process, EnvProvider).
+- `//nolint:gosec` — on `exec.CommandContext` (args are controlled by devctrl internals).
+- `//nolint:errorlint` — on `err.(*exec.ExitError)` casts that extract exit codes.

--- a/tools/lib/cmd/check.go
+++ b/tools/lib/cmd/check.go
@@ -16,8 +16,8 @@ func init() {
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Run all linting and static analysis sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args, checkGoCmd, checkWebCmd, checkProtoCmd)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(runPar(cmd.Context(), runner, checkGo, checkWeb, checkProto))
 	},
 }
 
@@ -25,7 +25,7 @@ var checkGoCmd = &cobra.Command{
 	Use:   "go",
 	Short: "Run golangci-lint on Go code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkGo(cmd.Context(), runner), "execute `golangci-lint run` command")
+		classifyAndExit(checkGo(cmd.Context(), runner))
 	},
 }
 
@@ -45,7 +45,7 @@ var checkWebCmd = &cobra.Command{
 	Use:   "web",
 	Short: "Run ESLint, Prettier, and svelte-check on web code",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkWeb(cmd.Context(), runner), "execute web lint commands")
+		classifyAndExit(checkWeb(cmd.Context(), runner))
 	},
 }
 
@@ -75,7 +75,7 @@ var checkProtoCmd = &cobra.Command{
 	Use:   "proto",
 	Short: "Run buf lint and format check on proto files",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(checkProto(cmd.Context(), runner), "execute proto lint commands")
+		classifyAndExit(checkProto(cmd.Context(), runner))
 	},
 }
 

--- a/tools/lib/cmd/generate.go
+++ b/tools/lib/cmd/generate.go
@@ -28,13 +28,15 @@ func init() {
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Run all code generation sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args,
-			generateProtoCmd,
-			generateSQLcCmd,
-			generateEnumCmd,
-		)
-		generateMockCmd.Run(cmd, args)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(runPar(cmd.Context(), runner,
+			generateProto,
+			generateSQLc,
+			func(ctx context.Context, r Runner) error {
+				return generateEnum(ctx, r, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models"))
+			},
+		))
+		classifyAndExit(generateAllMocks(cmd.Context(), runner))
 	},
 }
 
@@ -43,9 +45,9 @@ var generateProtoCmd = &cobra.Command{
 	Short: "Generate protobuf and gRPC code",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-		guard(generateProto(cmd.Context(), runner), "execute `buf ...` command")
+		classifyAndExit(generateProto(cmd.Context(), runner))
 
 		if !watchFlag {
 			return
@@ -79,9 +81,9 @@ var generateSQLcCmd = &cobra.Command{
 	Short: "Generate SQLc queries and data holders",
 	Run: func(cmd *cobra.Command, _ []string) {
 		watchFlag, err := cmd.Flags().GetBool("watch")
-		guard(err, "check '--watch' flag")
+		classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-		guard(generateSQLc(cmd.Context(), runner), "execute `sqlc ...` command")
+		classifyAndExit(generateSQLc(cmd.Context(), runner))
 
 		if !watchFlag {
 			return
@@ -114,7 +116,7 @@ var generateEnumCmd = &cobra.Command{
 	Use:   "enum",
 	Short: "Generate enum stringers",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(generateEnum(cmd.Context(), runner, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")), "execute `enumer ...` command for ")
+		classifyAndExit(generateEnum(cmd.Context(), runner, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")))
 	},
 }
 
@@ -133,24 +135,50 @@ func generateEnum(ctx context.Context, r Runner, typ, pkg string) error {
 var generateMockCmd = &cobra.Command{
 	Use:   "mock",
 	Short: "Generate IO clients' (DAO and SMS) interfaces and mocks",
-	Run: func(cmd *cobra.Command, args []string) {
-		runPar(cmd, args,
-			generateDBCMockCmd,
-			generateSMSMockCmd,
-		)
-		// generateDAOMockCmd must be called after generateDBCMockCmd.
-		generateDAOMockCmd.Run(cmd, args)
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(generateAllMocks(cmd.Context(), runner))
 	},
+}
+
+func generateAllMocks(ctx context.Context, r Runner) error {
+	// DBC and SMS mocks can run in parallel.
+	err := runPar(ctx, r,
+		func(ctx context.Context, r Runner) error {
+			return generateMock(ctx, r, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/"))
+		},
+		func(ctx context.Context, r Runner) error {
+			return generateInterfaceAndMock(ctx, r, smsConfig)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// generateDAOMock must be called after generateDBCMock.
+	return generateInterfaceAndMock(ctx, r, daoConfig)
+}
+
+var daoConfig = mockConfig{
+	targetStruct: "Queries",
+	ifaceName:    "QueryProvider",
+	ifaceComment: "QueryProvider describes all of the queries exposed by the DAO, to allow for testing mocks.",
+	genDir:       filepath.FromSlash("api/internal/lib/dao/"),
+	pkgName:      "dao",
+}
+
+var smsConfig = mockConfig{
+	targetStruct: "Client",
+	ifaceName:    "Messenger",
+	ifaceComment: "Messenger describes all of the operations exposed by the SMS client, to allow for testing mocks.",
+	genDir:       filepath.FromSlash("api/internal/lib/sms/"),
+	pkgName:      "sms",
 }
 
 var generateDBCMockCmd = &cobra.Command{
 	Use:   "dbc",
 	Short: "Generate DBC mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateMock(cmd.Context(), runner, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")),
-			"generate mock DBC",
-		)
+		classifyAndExit(generateMock(cmd.Context(), runner, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/")))
 	},
 }
 
@@ -158,16 +186,7 @@ var generateDAOMockCmd = &cobra.Command{
 	Use:   "dao",
 	Short: "Generate DAO interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
-				targetStruct: "Queries",
-				ifaceName:    "QueryProvider",
-				ifaceComment: "QueryProvider describes all of the queries exposed by the DAO, to allow for testing mocks.",
-				genDir:       filepath.FromSlash("api/internal/lib/dao/"),
-				pkgName:      "dao",
-			}),
-			"generate mock DAO",
-		)
+		classifyAndExit(generateInterfaceAndMock(cmd.Context(), runner, daoConfig))
 	},
 }
 
@@ -175,16 +194,7 @@ var generateSMSMockCmd = &cobra.Command{
 	Use:   "sms",
 	Short: "Generate SMS client interface and mock",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(
-			generateInterfaceAndMock(cmd.Context(), runner, mockConfig{
-				targetStruct: "Client",
-				ifaceName:    "Messenger",
-				ifaceComment: "Messenger describes all of the operations exposed by the SMS client, to allow for testing mocks.",
-				genDir:       filepath.FromSlash("api/internal/lib/sms/"),
-				pkgName:      "sms",
-			}),
-			"generate mock SMS Client",
-		)
+		classifyAndExit(generateInterfaceAndMock(cmd.Context(), runner, smsConfig))
 	},
 }
 

--- a/tools/lib/cmd/install.go
+++ b/tools/lib/cmd/install.go
@@ -30,15 +30,28 @@ func init() {
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Run all tool installation sub-tasks",
-	Run: func(cmd *cobra.Command, args []string) {
-		installers := []*cobra.Command{
-			installDopplerCmd,
-			installBufCmd,
+	Run: func(cmd *cobra.Command, _ []string) {
+		fns := []func(context.Context, Runner) error{
+			func(ctx context.Context, r Runner) error {
+				err := installWithHomebrew(ctx, r, "gnupg")
+				if err != nil {
+					return err
+				}
+
+				return installWithHomebrew(ctx, r, "dopplerhq/cli/doppler")
+			},
+			func(ctx context.Context, r Runner) error {
+				return installWithHomebrew(ctx, r, "bufbuild/buf/buf")
+			},
 		}
 
-		installers = append(installers, generateGoInstallers()...)
+		for _, pkg := range goTools {
+			fns = append(fns, func(ctx context.Context, r Runner) error {
+				return installWithGolang(ctx, r, pkg)
+			})
+		}
 
-		runPar(cmd, args, installers...)
+		classifyAndExit(runPar(cmd.Context(), runner, fns...))
 	},
 }
 
@@ -50,7 +63,7 @@ func generateGoInstallers() []*cobra.Command {
 			Use:   n,
 			Short: fmt.Sprintf("Install the %q CLI tool", n),
 			Run: func(cmd *cobra.Command, _ []string) {
-				guard(installWithGolang(cmd.Context(), runner, v), "install Go tool")
+				classifyAndExit(installWithGolang(cmd.Context(), runner, v))
 			},
 		})
 	}
@@ -62,8 +75,8 @@ var installDopplerCmd = &cobra.Command{
 	Use:   "doppler",
 	Short: "Install the `doppler` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(installWithHomebrew(cmd.Context(), runner, "gnupg"), "install gnupg")
-		guard(installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler"), "install doppler")
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "gnupg"))
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "dopplerhq/cli/doppler"))
 	},
 }
 
@@ -71,7 +84,7 @@ var installBufCmd = &cobra.Command{
 	Use:   "buf",
 	Short: "Install the `buf` CLI tool",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf"), "install buf")
+		classifyAndExit(installWithHomebrew(cmd.Context(), runner, "bufbuild/buf/buf"))
 	},
 }
 

--- a/tools/lib/cmd/migrate.go
+++ b/tools/lib/cmd/migrate.go
@@ -47,14 +47,14 @@ var migrateUpCmd = &cobra.Command{
 		m := getMigrator(cmd.Context())
 
 		if len(args) < 1 {
-			guard(m.Up(), "run up migration")
+			classifyAndExit(fmtErr(m.Up(), "run up migration"))
 
 			return
 		}
 
 		steps, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse number of migration steps")
-		guard(m.Steps(int(steps)), "run up migration")
+		classifyAndExit(fmtErr(err, "parse number of migration steps"))
+		classifyAndExit(fmtErr(m.Steps(int(steps)), "run up migration"))
 	},
 }
 
@@ -66,19 +66,19 @@ var migrateDownCmd = &cobra.Command{
 		m := getMigrator(cmd.Context())
 
 		if len(args) < 1 {
-			guard(m.Down(), "run up migration")
+			classifyAndExit(fmtErr(m.Down(), "run down migration"))
 
 			return
 		}
 
 		steps, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse number of migration steps")
+		classifyAndExit(fmtErr(err, "parse number of migration steps"))
 
 		if steps > 0 {
 			steps = -steps
 		}
 
-		guard(m.Steps(int(steps)), "run up migration")
+		classifyAndExit(fmtErr(m.Steps(int(steps)), "run down migration"))
 	},
 }
 
@@ -87,18 +87,21 @@ var migrateCreateCmd = &cobra.Command{
 	Short: "Create new migration files",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		migrateCreate(cmd.Context(), runner, args[0])
+		classifyAndExit(migrateCreate(cmd.Context(), runner, args[0]))
 	},
 }
 
-func migrateCreate(ctx context.Context, r Runner, name string) {
+func migrateCreate(ctx context.Context, r Runner, name string) error {
 	var migratorContent bytes.Buffer
 
-	guard(r.Run(ctx, Cmd{
+	err := r.Run(ctx, Cmd{
 		Name:   "migrate",
 		Args:   []string{"create", "-seq", "-ext", "sql", "-dir", migrationDirectory, name},
 		Stderr: io.MultiWriter(os.Stderr, &migratorContent),
-	}), "execute `migrate ...` command")
+	})
+	if err != nil {
+		return fmtErr(err, "execute `migrate ...` command")
+	}
 
 	outLines := strings.Split(migratorContent.String(), "\n")
 	foundFiles := false
@@ -112,17 +115,23 @@ func migrateCreate(ctx context.Context, r Runner, name string) {
 		foundFiles = true
 
 		f, err := os.OpenFile(name, os.O_RDWR, 0o644)
-		guard(err, "open migration file to add boilerplate")
+		if err != nil {
+			return fmtErr(err, "open migration file to add boilerplate")
+		}
 
 		defer f.Close()
 
 		_, err = f.WriteString("BEGIN;\n\n-- Migration logic goes here...\n\nCOMMIT;\n")
-		guard(err, "write boilerplate to migration file")
+		if err != nil {
+			return fmtErr(err, "write boilerplate to migration file")
+		}
 	}
 
 	if !foundFiles {
 		log.Println("WARNING: no migration files found in migrate output")
 	}
+
+	return nil
 }
 
 var migrateFixCmd = &cobra.Command{
@@ -132,27 +141,27 @@ var migrateFixCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		dbURL := getDatabaseURL(cmd.Context(), envProvider, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, false)
 		db, err := sql.Open(config.DBDriver.driverString(false), dbURL)
-		guard(err, "open DB connection")
+		classifyAndExit(fmtErr(err, "open DB connection"))
 
 		version, err := strconv.ParseInt(args[0], 10, 32)
-		guard(err, "parse desired version")
+		classifyAndExit(fmtErr(err, "parse desired version"))
 
 		if version < 1 {
 			_, err = db.Exec("DROP TABLE IF EXISTS schema_migrations;")
-			guard(err, "drop schema_migrations table")
+			classifyAndExit(fmtErr(err, "drop schema_migrations table"))
 
 			return
 		}
 
 		_, err = db.Exec("UPDATE schema_migrations SET version = $1, dirty = false;", version)
-		guard(err, "reset schema_migrations table")
+		classifyAndExit(fmtErr(err, "reset schema_migrations table"))
 	},
 }
 
 func getMigrator(ctx context.Context) *migrate.Migrate {
 	dbURL := getDatabaseURL(ctx, envProvider, config.DBDriver, config.ServerBinName, config.DopplerEnvName, config.EnvVarPrefix, true)
 	m, err := migrate.New(migrationSource, dbURL)
-	guard(err, "construct DB migrator")
+	classifyAndExit(fmtErr(err, "construct DB migrator"))
 
 	return m
 }

--- a/tools/lib/cmd/root.go
+++ b/tools/lib/cmd/root.go
@@ -162,7 +162,9 @@ func runPar(ctx context.Context, r Runner, fns ...func(context.Context, Runner) 
 			}
 
 			mu.Lock()
+
 			errs = append(errs, err)
+
 			mu.Unlock()
 		})
 	}

--- a/tools/lib/cmd/root.go
+++ b/tools/lib/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -134,7 +135,7 @@ func init() {
 
 func checkVersion() {
 	curToolsHash, err := dirhash.HashDir(filepath.Join(projectRoot, "tools"), "", dirhash.DefaultHash)
-	guard(err, "hash tools dir")
+	classifyAndExit(fmtErr(err, "hash tools dir"))
 
 	if installedToolsHash != curToolsHash {
 		log.Printf(`The installed version of %[1]s is out of date. Run the following to update:
@@ -145,29 +146,30 @@ func checkVersion() {
 	}
 }
 
-// guard logs and exits on error.
-func guard(err error, msg string) {
-	if err != nil {
-		log.Fatalf("%s: %v", msg, err.Error())
-	}
-}
+// runPar executes all of the specified functions in parallel and returns a joined error.
+func runPar(ctx context.Context, r Runner, fns ...func(context.Context, Runner) error) error {
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
 
-// runPar executes all of the specified commands in parallel.
-func runPar(cmd *cobra.Command, args []string, commands ...*cobra.Command) {
-	var wg sync.WaitGroup
+	for _, fn := range fns {
+		wg.Go(func() {
+			err := fn(ctx, r)
+			if err == nil {
+				return
+			}
 
-	wg.Add(len(commands))
-
-	for _, c := range commands {
-		go func(cmd *cobra.Command, args []string, c *cobra.Command) {
-			defer wg.Done()
-
-			log.Printf("Running `%s`...\n", c.Use)
-			c.Run(cmd, args)
-		}(cmd, args, c)
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+		})
 	}
 
 	wg.Wait()
+
+	return errors.Join(errs...)
 }
 
 // ignoredDirPatterns lists directory names that file watchers should skip.
@@ -202,15 +204,15 @@ func watch(dir, label string, callback func(watcher.Event)) {
 				callback(ev)
 				log.Printf("Task '%s' completed.\n", label)
 			case err := <-w.Error:
-				guard(err, "watcher failed")
+				classifyAndExit(fmtErr(err, "watcher failed"))
 			case <-w.Closed:
 				return
 			}
 		}
 	}()
 
-	guard(w.AddRecursive(dir), "create watcher")
+	classifyAndExit(fmtErr(w.AddRecursive(dir), "create watcher"))
 	log.Printf("Watching '%s' for changes...\n", dir)
 
-	go guard(w.Start(100*time.Millisecond), "start watcher")
+	go classifyAndExit(fmtErr(w.Start(100*time.Millisecond), "start watcher"))
 }

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -23,10 +23,12 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run all server executables",
 	Run: func(cmd *cobra.Command, args []string) {
-		runAPIBgCmd.Run(cmd, args)
-		runPar(cmd, args,
-			runAPIServerCmd,
-		)
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
+			"api-db",
+		))
+
+		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
+		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
 	},
 }
 
@@ -43,10 +45,10 @@ var runAPIBgCmd = &cobra.Command{
 	Use:   "bg",
 	Short: "Run all supporting services for the API server",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
 			"api-db",
 			// "api-blob-storage",
-		), "execute `docker-compose up ...` command")
+		))
 	},
 }
 
@@ -54,8 +56,7 @@ var runAPIDatabaseCmd = &cobra.Command{
 	Use:   "api-db",
 	Short: "Run API server's DB instance",
 	Run: func(cmd *cobra.Command, _ []string) {
-		guard(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName, "api-db"),
-			"execute `docker-compose up ...` command")
+		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName, "api-db"))
 	},
 }
 
@@ -96,7 +97,7 @@ func dockerRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg st
 
 func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
-	guard(err, "check '--watch' flag")
+	classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
 	// Start initial process
 	proc := startGoRun(cmd.Context(), r, ep, project, envCfg, bin, args)
@@ -126,7 +127,7 @@ func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCf
 
 func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process { //nolint:ireturn // Returns Process interface by design.
 	env, err := ep.Env(ctx, project, envCfg)
-	guard(err, "fetch go run environment")
+	classifyAndExit(fmtErr(err, "fetch go run environment"))
 
 	allArgs := append([]string{"run", bin}, args...)
 
@@ -137,7 +138,7 @@ func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, 
 		Args: allArgs,
 		Env:  env,
 	})
-	guard(startErr, "execute `go run ...` command")
+	classifyAndExit(fmtErr(startErr, "execute `go run ...` command"))
 
 	return proc
 }

--- a/tools/lib/cmd/runner_test.go
+++ b/tools/lib/cmd/runner_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,4 +149,38 @@ func splitEnvVar(s string) [2]string {
 	}
 
 	return [2]string{s[:i], s[i+1:]}
+}
+
+var (
+	errRunParA = fmt.Errorf("error A: %w", errSimulated)
+	errRunParB = fmt.Errorf("error B: %w", errSimulated)
+)
+
+func TestRunParCollectsErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dr := &DryRunner{}
+
+	err := runPar(ctx, dr,
+		func(_ context.Context, _ Runner) error { return errRunParA },
+		func(_ context.Context, _ Runner) error { return nil },
+		func(_ context.Context, _ Runner) error { return errRunParB },
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errRunParA)
+	require.ErrorIs(t, err, errRunParB)
+}
+
+func TestRunParNoErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dr := &DryRunner{}
+
+	err := runPar(ctx, dr,
+		func(_ context.Context, _ Runner) error { return nil },
+		func(_ context.Context, _ Runner) error { return nil },
+	)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- Refactor `runPar` to accept error-returning functions with `(context.Context, Runner)` params, collecting all errors via `errors.Join`
- Use `wg.Go` instead of manual `wg.Add(1)` / `defer wg.Done()`
- Migrate remaining `guard` calls in check, generate, install, migrate, root, and run commands to `classifyAndExit`
- Remove `guard` function entirely
- Add `tools/CLAUDE.md` (+ `AGENTS.md` symlink) documenting devctrl patterns and conventions

Stacked on #586 (devctrl/05a-error-infra).

## Test plan
- [x] `go build ./tools/...` passes
- [x] `go test ./tools/lib/cmd/...` passes (72 tests, including new runPar tests)
- [ ] Verify `guard` is fully removed (`grep -r 'guard(' tools/` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)