### PR TITLE
Wave 4 / Plan 09: test suite and CLAUDE.md agent guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,13 @@ shorthand for permission grouping, not the actual CLI syntax.
 | Check web app (lint + type-check) | `pubgolf-devctrl check web` | auto-approved |
 | Install dev deps | `pubgolf-devctrl install *` | auto-approved |
 | Stop servers | `pubgolf-devctrl stop *` | auto-approved |
+| Inspect worktree status | `pubgolf-devctrl status` | auto-approved |
+| Inspect all worktrees | `pubgolf-devctrl status --all` | auto-approved |
+| Check dev environment | `pubgolf-devctrl doctor` | auto-approved |
+| Preview cleanup | `pubgolf-devctrl clean` | auto-approved |
+| Dry-run any command | `pubgolf-devctrl --dry-run <cmd>` | auto-approved |
 | Update devctrl itself | `pubgolf-devctrl update *` | requires approval |
+| Force cleanup | `pubgolf-devctrl clean --force` | requires approval |
 
 **Single-package Go tests**: `pubgolf-devctrl test` always runs the full suite with
 Doppler secrets. For iterating on a single package (no DB/secrets needed), use
@@ -92,6 +98,16 @@ to run manually rather than blocking mid-task.
 
 `pubgolf-devctrl update` will trigger an approval prompt mid-task. Do not invoke it
 as part of an automated sequence unless it is necessary specifically for tool development.
+
+## Exit Codes
+- Exit 1: test/lint failure (debug your code).
+- Exit 2: infrastructure failure (check services, not your code).
+
+## Worktree Port Collisions
+If you encounter "address already in use", set `PUBGOLF_PORT_OFFSET` to a
+number between 1 and 499 and retry:
+
+    export PUBGOLF_PORT_OFFSET=42
 
 ## Testing
 Go tests use [Testify](https://github.com/stretchr/testify). Use `require` for

--- a/tools/lib/cmd/check_test.go
+++ b/tools/lib/cmd/check_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckGo_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := checkGo(context.Background(), dr)
+	require.NoError(t, err)
+
+	// checkGo runs golangci-lint cache clean + lint for each of 2 directories.
+	require.Len(t, dr.Recorded, 4)
+
+	// First pair: cache clean, then lint ./api/...
+	assert.Equal(t, "golangci-lint", dr.Recorded[0].Name)
+	assert.Equal(t, []string{"cache", "clean"}, dr.Recorded[0].Args)
+
+	assert.Equal(t, "golangci-lint", dr.Recorded[1].Name)
+	assert.Equal(t, []string{"run", "./api/..."}, dr.Recorded[1].Args)
+
+	// Second pair: cache clean, then lint ./tools/...
+	assert.Equal(t, "golangci-lint", dr.Recorded[2].Name)
+	assert.Equal(t, []string{"cache", "clean"}, dr.Recorded[2].Args)
+
+	assert.Equal(t, "golangci-lint", dr.Recorded[3].Name)
+	assert.Equal(t, []string{"run", "./tools/..."}, dr.Recorded[3].Args)
+}
+
+func TestCheckGo_StopsOnCacheCleanError(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"golangci-lint": errSimulated,
+		},
+	}
+
+	err := checkGo(context.Background(), dr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+
+	// Should have stopped after the first failed command.
+	assert.Len(t, dr.Recorded, 1)
+}
+
+func TestCheckWeb_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := checkWeb(context.Background(), dr)
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 2)
+
+	assert.Equal(t, "npm", dr.Recorded[0].Name)
+	assert.Equal(t, []string{"run", "ci:lint"}, dr.Recorded[0].Args)
+	assert.Equal(t, "web-app", dr.Recorded[0].Dir)
+
+	assert.Equal(t, "npm", dr.Recorded[1].Name)
+	assert.Equal(t, []string{"run", "check"}, dr.Recorded[1].Args)
+	assert.Equal(t, "web-app", dr.Recorded[1].Dir)
+}
+
+func TestCheckWeb_StopsOnFirstError(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"npm": errSimulated,
+		},
+	}
+
+	err := checkWeb(context.Background(), dr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+	assert.Len(t, dr.Recorded, 1)
+}
+
+func TestCheckProto_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := checkProto(context.Background(), dr)
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 2)
+
+	assert.Equal(t, "buf", dr.Recorded[0].Name)
+	assert.Equal(t, []string{"lint"}, dr.Recorded[0].Args)
+
+	assert.Equal(t, "buf", dr.Recorded[1].Name)
+	assert.Equal(t, []string{"format", "./proto/", "--diff", "--exit-code"}, dr.Recorded[1].Args)
+}
+
+func TestCheckProto_StopsOnLintError(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"buf": errSimulated,
+		},
+	}
+
+	err := checkProto(context.Background(), dr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+	assert.Len(t, dr.Recorded, 1)
+}

--- a/tools/lib/cmd/config_test.go
+++ b/tools/lib/cmd/config_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCLIConfig_SetDefaults(t *testing.T) {
+	t.Parallel()
+
+	c := CLIConfig{ProjectName: "pubgolf"}
+	c.setDefaults()
+
+	assert.Equal(t, "pubgolf-devctrl", c.CLIName)
+	assert.Equal(t, "pubgolf-api-server", c.ServerBinName)
+	assert.Equal(t, "dev", c.DopplerEnvName)
+}
+
+func TestCLIConfig_SetDefaults_PreservesExplicitValues(t *testing.T) {
+	t.Parallel()
+
+	c := CLIConfig{
+		ProjectName:    "pubgolf",
+		CLIName:        "custom-cli",
+		ServerBinName:  "custom-server",
+		DopplerEnvName: "staging",
+	}
+	c.setDefaults()
+
+	assert.Equal(t, "custom-cli", c.CLIName)
+	assert.Equal(t, "custom-server", c.ServerBinName)
+	assert.Equal(t, "staging", c.DopplerEnvName)
+}
+
+func TestGetStr_ReturnsValue(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]string{"key": "value"}
+	assert.Equal(t, "value", getStr(m, "key", "default"))
+}
+
+func TestGetStr_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]string{}
+	assert.Equal(t, "default", getStr(m, "missing", "default"))
+}
+
+func TestDBDriverString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		driver     DBDriver
+		isMigrator bool
+		want       string
+	}{
+		{name: "postgres non-migrator", driver: PostgreSQL, isMigrator: false, want: "pgx"},
+		{name: "postgres migrator", driver: PostgreSQL, isMigrator: true, want: "pgx5"},
+		{name: "sqlite3", driver: SQLite3, isMigrator: false, want: "sqlite3"},
+		{name: "none", driver: None, isMigrator: false, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.driver.driverString(tt.isMigrator))
+		})
+	}
+}

--- a/tools/lib/cmd/generate_test.go
+++ b/tools/lib/cmd/generate_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateProto_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := generateProto(context.Background(), dr)
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 1)
+
+	cmd := dr.Recorded[0]
+	assert.Equal(t, "buf", cmd.Name)
+	assert.Equal(t, []string{"generate", "--template", filepath.FromSlash("buf.gen.dev.yaml")}, cmd.Args)
+}
+
+func TestGenerateProto_Error(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"buf": errSimulated,
+		},
+	}
+
+	err := generateProto(context.Background(), dr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+}
+
+func TestGenerateSQLc_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := generateSQLc(context.Background(), dr)
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 1)
+
+	cmd := dr.Recorded[0]
+	assert.Equal(t, "sqlc", cmd.Name)
+	assert.Equal(t, []string{"generate", "--file", filepath.FromSlash("api/internal/db/sqlc.yaml")}, cmd.Args)
+}
+
+func TestGenerateEnum_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := generateEnum(context.Background(), dr, "ScoringCategory", filepath.FromSlash("./api/internal/lib/models"))
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 1)
+
+	cmd := dr.Recorded[0]
+	assert.Equal(t, "enumer", cmd.Name)
+	assert.Equal(t, []string{"-sql", "-transform", "snake-upper", "-type", "ScoringCategory", filepath.FromSlash("./api/internal/lib/models")}, cmd.Args)
+}
+
+func TestGenerateEnum_Error(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"enumer": errSimulated,
+		},
+	}
+
+	err := generateEnum(context.Background(), dr, "ScoringCategory", "./api/internal/lib/models")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+}
+
+func TestGenerateMock_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	err := generateMock(context.Background(), dr, "Querier", filepath.FromSlash("api/internal/lib/dao/internal/dbc/"))
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 1)
+
+	cmd := dr.Recorded[0]
+	assert.Equal(t, "mockery", cmd.Name)
+	assert.Contains(t, cmd.Args, "--dir")
+	assert.Contains(t, cmd.Args, filepath.FromSlash("api/internal/lib/dao/internal/dbc/"))
+	assert.Contains(t, cmd.Args, "--name")
+	assert.Contains(t, cmd.Args, "Querier")
+	assert.Contains(t, cmd.Args, "--filename")
+	assert.Contains(t, cmd.Args, "gen_mock.go")
+	assert.Contains(t, cmd.Args, "--inpackage")
+}
+
+func TestGenerateMock_Error(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{
+		ErrorFor: map[string]error{
+			"mockery": errSimulated,
+		},
+	}
+
+	err := generateMock(context.Background(), dr, "Querier", "api/internal/lib/dao/internal/dbc/")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSimulated)
+}

--- a/tools/lib/cmd/root_test.go
+++ b/tools/lib/cmd/root_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveProjectRoot_FromRoot(t *testing.T) { //nolint:paralleltest // t.Chdir is incompatible with t.Parallel.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o600))
+
+	t.Chdir(dir)
+
+	root, err := resolveProjectRoot()
+	require.NoError(t, err)
+	assert.Equal(t, dir, root)
+}
+
+func TestResolveProjectRoot_FromSubdir(t *testing.T) { //nolint:paralleltest // t.Chdir is incompatible with t.Parallel.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o600))
+
+	subdir := filepath.Join(dir, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	t.Chdir(subdir)
+
+	root, err := resolveProjectRoot()
+	require.NoError(t, err)
+	assert.Equal(t, dir, root)
+}
+
+func TestResolveProjectRoot_NotFound(t *testing.T) { //nolint:paralleltest // t.Chdir is incompatible with t.Parallel.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	t.Chdir(dir)
+
+	_, err = resolveProjectRoot()
+	require.ErrorIs(t, err, errProjectRootNotFound)
+}

--- a/tools/lib/cmd/run_test.go
+++ b/tools/lib/cmd/run_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerRun_CommandConstruction(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ep := &dryRunProvider{}
+
+	// Save and restore package-level projectRoot since dockerRun uses it.
+	origRoot := projectRoot
+	projectRoot = "/tmp/test-project"
+
+	defer func() { projectRoot = origRoot }()
+
+	err := dockerRun(context.Background(), dr, ep, "pubgolf-api-server", "dev", "api-db")
+	require.NoError(t, err)
+
+	require.Len(t, dr.Recorded, 1)
+
+	cmd := dr.Recorded[0]
+	assert.Equal(t, "docker", cmd.Name)
+	assert.Contains(t, cmd.Args, "compose")
+	assert.Contains(t, cmd.Args, "--file")
+	assert.Contains(t, cmd.Args, filepath.FromSlash("./infra/docker-compose.dev.yaml"))
+	assert.Contains(t, cmd.Args, "--project-name")
+	assert.Contains(t, cmd.Args, "up")
+	assert.Contains(t, cmd.Args, "--detach")
+	assert.Contains(t, cmd.Args, "api-db")
+}
+
+func TestDockerRun_InjectsPortEnv(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ep := &dryRunProvider{}
+
+	origRoot := projectRoot
+	projectRoot = "/tmp/test-project"
+
+	defer func() { projectRoot = origRoot }()
+
+	err := dockerRun(context.Background(), dr, ep, "pubgolf-api-server", "dev", "api-db")
+	require.NoError(t, err)
+	require.Len(t, dr.Recorded, 1)
+
+	// Verify port-related env vars are injected.
+	env := dr.Recorded[0].Env
+	hasDBPort := false
+	hasAPIPort := false
+	hasDataPath := false
+
+	for _, e := range env {
+		if len(e) >= len("PUBGOLF_DB_PORT=") && e[:len("PUBGOLF_DB_PORT=")] == "PUBGOLF_DB_PORT=" {
+			hasDBPort = true
+		}
+
+		if len(e) >= len("PUBGOLF_PORT=") && e[:len("PUBGOLF_PORT=")] == "PUBGOLF_PORT=" {
+			hasAPIPort = true
+		}
+
+		if len(e) >= len("PUBGOLF_DB_HOST_DATA_PATH=") && e[:len("PUBGOLF_DB_HOST_DATA_PATH=")] == "PUBGOLF_DB_HOST_DATA_PATH=" {
+			hasDataPath = true
+		}
+	}
+
+	assert.True(t, hasDBPort, "expected PUBGOLF_DB_PORT in env")
+	assert.True(t, hasAPIPort, "expected PUBGOLF_PORT in env")
+	assert.True(t, hasDataPath, "expected PUBGOLF_DB_HOST_DATA_PATH in env")
+}
+
+func TestDockerRun_EnvProviderError(t *testing.T) {
+	t.Parallel()
+
+	dr := &DryRunner{}
+	ep := &DryRunner{
+		ErrorFor: map[string]error{
+			"doppler": errSimulated,
+		},
+	}
+
+	// Use a DopplerProvider that will fail since DryRunner can't capture stdout.
+	dp := &DopplerProvider{Runner: ep}
+
+	origRoot := projectRoot
+	projectRoot = "/tmp/test-project"
+
+	defer func() { projectRoot = origRoot }()
+
+	err := dockerRun(context.Background(), dr, dp, "pubgolf-api-server", "dev", "api-db")
+	require.Error(t, err)
+}

--- a/tools/lib/cmd/test_test.go
+++ b/tools/lib/cmd/test_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceSharedDBPort_ReplacesPort(t *testing.T) {
+	t.Parallel()
+
+	env := []string{
+		"SOME_VAR=hello",
+		"PUBGOLF_SHARED_DB_URL=postgres://user:pass@localhost:5432/dbname?sslmode=disable",
+		"OTHER_VAR=world",
+	}
+
+	result := replaceSharedDBPort(env, 5)
+
+	// The port should be 5432 + 5 = 5437.
+	assert.Contains(t, result[1], "5437")
+	assert.Contains(t, result[1], "PUBGOLF_SHARED_DB_URL=")
+	// Other vars should be unchanged.
+	assert.Equal(t, "SOME_VAR=hello", result[0])
+	assert.Equal(t, "OTHER_VAR=world", result[2])
+}
+
+func TestReplaceSharedDBPort_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"SOME_VAR=hello", "OTHER_VAR=world"}
+	result := replaceSharedDBPort(env, 5)
+
+	assert.Equal(t, env, result)
+}
+
+func TestReplaceSharedDBPort_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"PUBGOLF_SHARED_DB_URL=://invalid"}
+	result := replaceSharedDBPort(env, 5)
+
+	// Should return env unchanged when URL can't be parsed.
+	assert.Equal(t, env, result)
+}
+
+func TestPreflight_SucceedsWhenPortOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Start a listener on a random port to simulate a running DB.
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(ctx, "tcp", "localhost:0")
+	require.NoError(t, err)
+
+	defer ln.Close()
+
+	// Extract the port from the listener's address.
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok, "expected *net.TCPAddr")
+
+	offset := addr.Port - 5432
+
+	err = preflight(ctx, offset)
+	assert.NoError(t, err)
+}
+
+func TestPreflight_FailsWhenPortClosed(t *testing.T) {
+	t.Parallel()
+
+	// Use a port that is almost certainly not listening.
+	// Offset of 499 → port 5931 — unlikely to be in use in a test environment.
+	err := preflight(context.Background(), 499)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errDBNotRunning)
+}


### PR DESCRIPTION
## Summary
- Add comprehensive DryRunner-based test suite for all devctrl command handlers: `checkGo`, `checkWeb`, `checkProto`, `generateProto`, `generateSQLc`, `generateEnum`, `generateMock`, `dockerRun`
- Add tests for config defaults (`CLIConfig.setDefaults`), project root resolution (`resolveProjectRoot`), shared DB port replacement (`replaceSharedDBPort`), preflight health checks, and error simulation via `DryRunner.ErrorFor`
- Update CLAUDE.md with new devctrl commands (`status`, `doctor`, `clean`, `--dry-run`), exit code semantics (1=code failure, 2=infra failure), and `PUBGOLF_PORT_OFFSET` worktree port collision guidance

## Test plan
- [x] `go test ./tools/...` passes (105 tests)
- [x] `pubgolf-devctrl check go` passes (0 lint issues)
- [ ] CI green

## Merge instructions
Merge via GitHub once CI is green and review is approved. This is part of Wave 4 of the devctrl worktree robustness refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)