### PR TITLE
test(forms): add unit tests for score submission forms

### DIFF
--- a/api/internal/lib/forms/forms_test.go
+++ b/api/internal/lib/forms/forms_test.go
@@ -158,14 +158,28 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 	id2 := ulid.Make()
 	id3 := ulid.Make()
 
-	t.Run("new score no adjustments", func(t *testing.T) {
+	t.Run("zero score uses submit labels", func(t *testing.T) {
 		t.Parallel()
 
 		form := GenerateSubmitScoreForm(0, nil)
 
 		assert.Equal(t, "Submit Your Score", form.GetLabel())
 		assert.Equal(t, "Submit", form.GetActionLabel())
-		require.Len(t, form.GetGroups(), 1)
+	})
+
+	t.Run("nonzero score uses edit labels", func(t *testing.T) {
+		t.Parallel()
+
+		form := GenerateSubmitScoreForm(5, nil)
+
+		assert.Equal(t, "Edit Your Score", form.GetLabel())
+		assert.Equal(t, "Re-Submit", form.GetActionLabel())
+	})
+
+	t.Run("zero score has no default sips value", func(t *testing.T) {
+		t.Parallel()
+
+		form := GenerateSubmitScoreForm(0, nil)
 
 		sipsInput := form.GetGroups()[0].GetInputs()[0]
 		assert.Equal(t, SubmitScoreInputIDSips, sipsInput.GetId())
@@ -175,18 +189,21 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		assert.Nil(t, numVariant.Numeric.DefaultValue)
 	})
 
-	t.Run("edit score no adjustments", func(t *testing.T) {
+	t.Run("nonzero score defaults sips to current score", func(t *testing.T) {
 		t.Parallel()
 
 		form := GenerateSubmitScoreForm(5, nil)
 
-		assert.Equal(t, "Edit Your Score", form.GetLabel())
-		assert.Equal(t, "Re-Submit", form.GetActionLabel())
-		require.Len(t, form.GetGroups(), 1)
-
 		numVariant, ok := form.GetGroups()[0].GetInputs()[0].GetVariant().(*apiv1.FormInput_Numeric)
 		require.True(t, ok)
 		assert.Equal(t, int64(5), numVariant.Numeric.GetDefaultValue())
+	})
+
+	t.Run("nil adjustments produces only sips group", func(t *testing.T) {
+		t.Parallel()
+
+		form := GenerateSubmitScoreForm(0, nil)
+		require.Len(t, form.GetGroups(), 1)
 	})
 
 	t.Run("venue specific adjustments only", func(t *testing.T) {
@@ -412,5 +429,23 @@ func TestParseSubmitScoreForm(t *testing.T) {
 			selectManyVal(SubmitScoreInputIDVenueAdj, []string{"not-a-ulid"}),
 		})
 		require.Error(t, err)
+	})
+
+	t.Run("nil form value in slice returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{nil, numericVal(3)})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnexpectedInput)
+	})
+
+	t.Run("nil sips form value returns wrong variant", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			{Id: SubmitScoreInputIDSips},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrWrongInputVariant)
 	})
 }

--- a/api/internal/lib/forms/forms_test.go
+++ b/api/internal/lib/forms/forms_test.go
@@ -1,0 +1,409 @@
+package forms
+
+import (
+	"testing"
+
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestParseFormValueNumeric(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		fv      *apiv1.FormValue
+		want    int64
+		wantErr error
+	}{
+		{
+			name: "valid numeric",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_Numeric{Numeric: 5},
+			},
+			want: 5,
+		},
+		{
+			name: "zero",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_Numeric{Numeric: 0},
+			},
+			want: 0,
+		},
+		{
+			name: "negative",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_Numeric{Numeric: -3},
+			},
+			want: -3,
+		},
+		{
+			name: "wrong variant select many",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_SelectMany{
+					SelectMany: &apiv1.SelectManyValue{SelectedIds: []string{"a"}},
+				},
+			},
+			wantErr: ErrWrongInputVariant,
+		},
+		{
+			name:    "nil variant",
+			fv:      &apiv1.FormValue{},
+			wantErr: ErrWrongInputVariant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseFormValueNumeric(tt.fv)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseFormValueSelectMany(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		fv      *apiv1.FormValue
+		want    []string
+		wantErr error
+	}{
+		{
+			name: "valid with options",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_SelectMany{
+					SelectMany: &apiv1.SelectManyValue{SelectedIds: []string{"a", "b"}},
+				},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "empty selection",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_SelectMany{
+					SelectMany: &apiv1.SelectManyValue{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "wrong variant numeric",
+			fv: &apiv1.FormValue{
+				Value: &apiv1.FormValue_Numeric{Numeric: 5},
+			},
+			wantErr: ErrWrongInputVariant,
+		},
+		{
+			name:    "nil variant",
+			fv:      &apiv1.FormValue{},
+			wantErr: ErrWrongInputVariant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseFormValueSelectMany(tt.fv)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func makeAdjTemplate(id ulid.ULID, label string, value int32, venueSpecific, active bool) models.AdjustmentTemplate {
+	return models.AdjustmentTemplate{
+		ID:            models.AdjustmentTemplateIDFromULID(id),
+		Label:         label,
+		Value:         value,
+		VenueSpecific: venueSpecific,
+		Active:        active,
+	}
+}
+
+func TestGenerateSubmitScoreForm(t *testing.T) {
+	t.Parallel()
+
+	id1 := ulid.Make()
+	id2 := ulid.Make()
+	id3 := ulid.Make()
+
+	t.Run("new score no adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		form := GenerateSubmitScoreForm(0, nil)
+
+		assert.Equal(t, "Submit Your Score", form.GetLabel())
+		assert.Equal(t, "Submit", form.GetActionLabel())
+		require.Len(t, form.GetGroups(), 1)
+
+		sipsInput := form.GetGroups()[0].GetInputs()[0]
+		assert.Equal(t, SubmitScoreInputIDSips, sipsInput.GetId())
+
+		numVariant, ok := sipsInput.GetVariant().(*apiv1.FormInput_Numeric)
+		require.True(t, ok)
+		assert.Nil(t, numVariant.Numeric.DefaultValue)
+	})
+
+	t.Run("edit score no adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		form := GenerateSubmitScoreForm(5, nil)
+
+		assert.Equal(t, "Edit Your Score", form.GetLabel())
+		assert.Equal(t, "Re-Submit", form.GetActionLabel())
+		require.Len(t, form.GetGroups(), 1)
+
+		numVariant, ok := form.GetGroups()[0].GetInputs()[0].GetVariant().(*apiv1.FormInput_Numeric)
+		require.True(t, ok)
+		assert.Equal(t, int64(5), numVariant.Numeric.GetDefaultValue())
+	})
+
+	t.Run("venue specific adjustments only", func(t *testing.T) {
+		t.Parallel()
+
+		adj := []models.AdjustmentTemplate{
+			makeAdjTemplate(id1, "Bonus", 1, true, false),
+		}
+
+		form := GenerateSubmitScoreForm(0, adj)
+		require.Len(t, form.GetGroups(), 2)
+		assert.Equal(t, "Venue-Specific Events", form.GetGroups()[1].GetLabel())
+	})
+
+	t.Run("standard adjustments only", func(t *testing.T) {
+		t.Parallel()
+
+		adj := []models.AdjustmentTemplate{
+			makeAdjTemplate(id1, "Penalty", -1, false, false),
+		}
+
+		form := GenerateSubmitScoreForm(0, adj)
+		require.Len(t, form.GetGroups(), 2)
+		assert.Equal(t, "Did you commit any party fouls?", form.GetGroups()[1].GetLabel())
+	})
+
+	t.Run("both adjustment types", func(t *testing.T) {
+		t.Parallel()
+
+		adj := []models.AdjustmentTemplate{
+			makeAdjTemplate(id1, "Venue Bonus", 1, true, false),
+			makeAdjTemplate(id2, "Standard Penalty", -1, false, false),
+		}
+
+		form := GenerateSubmitScoreForm(0, adj)
+		require.Len(t, form.GetGroups(), 3)
+		assert.Equal(t, "Venue-Specific Events", form.GetGroups()[1].GetLabel())
+		assert.Equal(t, "Did you commit any party fouls?", form.GetGroups()[2].GetLabel())
+	})
+
+	t.Run("active flag maps to default value", func(t *testing.T) {
+		t.Parallel()
+
+		adj := []models.AdjustmentTemplate{
+			makeAdjTemplate(id1, "Active", 1, false, true),
+			makeAdjTemplate(id2, "Inactive", -1, false, false),
+			makeAdjTemplate(id3, "Also Active", 2, false, true),
+		}
+
+		form := GenerateSubmitScoreForm(0, adj)
+		require.Len(t, form.GetGroups(), 2)
+
+		smVariant, ok := form.GetGroups()[1].GetInputs()[0].GetVariant().(*apiv1.FormInput_SelectMany)
+		require.True(t, ok)
+
+		selectMany := smVariant.SelectMany
+		opts := selectMany.GetOptions()
+		require.Len(t, opts, 3)
+
+		assert.True(t, opts[0].GetDefaultValue())
+		assert.False(t, opts[1].GetDefaultValue())
+		assert.True(t, opts[2].GetDefaultValue())
+	})
+}
+
+func TestParseSubmitScoreForm(t *testing.T) {
+	t.Parallel()
+
+	id1 := ulid.Make()
+	id2 := ulid.Make()
+	id3 := ulid.Make()
+
+	numericVal := func(n int64) *apiv1.FormValue {
+		return &apiv1.FormValue{
+			Id:    SubmitScoreInputIDSips,
+			Value: &apiv1.FormValue_Numeric{Numeric: n},
+		}
+	}
+
+	selectManyVal := func(id string, ids []string) *apiv1.FormValue {
+		return &apiv1.FormValue{
+			Id: id,
+			Value: &apiv1.FormValue_SelectMany{
+				SelectMany: &apiv1.SelectManyValue{SelectedIds: ids},
+			},
+		}
+	}
+
+	t.Run("valid score only", func(t *testing.T) {
+		t.Parallel()
+
+		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(3)})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(3), score)
+		assert.Empty(t, adj)
+	})
+
+	t.Run("score with venue adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			numericVal(5),
+			selectManyVal(SubmitScoreInputIDVenueAdj, []string{id1.String(), id2.String()}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(5), score)
+		require.Len(t, adj, 2)
+		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id1), adj[0])
+		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id2), adj[1])
+	})
+
+	t.Run("score with standard adjustments", func(t *testing.T) {
+		t.Parallel()
+
+		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			numericVal(2),
+			selectManyVal(SubmitScoreInputIDStandardAdj, []string{id1.String()}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(2), score)
+		require.Len(t, adj, 1)
+		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id1), adj[0])
+	})
+
+	t.Run("score with both adjustment types", func(t *testing.T) {
+		t.Parallel()
+
+		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			numericVal(4),
+			selectManyVal(SubmitScoreInputIDVenueAdj, []string{id1.String()}),
+			selectManyVal(SubmitScoreInputIDStandardAdj, []string{id2.String(), id3.String()}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(4), score)
+		require.Len(t, adj, 3)
+	})
+
+	t.Run("boundary min sips", func(t *testing.T) {
+		t.Parallel()
+
+		score, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(SubmitScoreSipsMin)})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(SubmitScoreSipsMin), score)
+	})
+
+	t.Run("boundary max sips", func(t *testing.T) {
+		t.Parallel()
+
+		score, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(SubmitScoreSipsMax)})
+		require.NoError(t, err)
+		assert.Equal(t, uint32(SubmitScoreSipsMax), score)
+	})
+
+	t.Run("error missing sips", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMissingRequiredInput)
+	})
+
+	t.Run("error empty form", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMissingRequiredInput)
+	})
+
+	t.Run("error sips below min", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(0)})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
+	})
+
+	t.Run("error sips above max", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(11)})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
+	})
+
+	t.Run("error sips negative", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(-1)})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
+	})
+
+	t.Run("error sips wrong variant", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			selectManyVal(SubmitScoreInputIDSips, []string{"a"}),
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrWrongInputVariant)
+	})
+
+	t.Run("error unknown input id", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			numericVal(3),
+			{
+				Id:    "#unknown",
+				Value: &apiv1.FormValue_Numeric{Numeric: 1},
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnexpectedInput)
+	})
+
+	t.Run("error invalid adjustment ulid", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{
+			numericVal(3),
+			selectManyVal(SubmitScoreInputIDVenueAdj, []string{"not-a-ulid"}),
+		})
+		require.Error(t, err)
+	})
+}

--- a/api/internal/lib/forms/forms_test.go
+++ b/api/internal/lib/forms/forms_test.go
@@ -235,22 +235,22 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		assert.Equal(t, "Did you commit any party fouls?", form.GetGroups()[1].GetLabel())
 	})
 
-	t.Run("venue and standard adjustments produce separate groups", func(t *testing.T) {
+	t.Run("venue group before standard group regardless of input order", func(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
 			{
 				ID:            models.AdjustmentTemplateIDFromULID(id1),
-				Label:         "Venue Bonus",
-				Value:         1,
-				VenueSpecific: true,
+				Label:         "Standard Penalty",
+				Value:         -1,
+				VenueSpecific: false,
 				Active:        false,
 			},
 			{
 				ID:            models.AdjustmentTemplateIDFromULID(id2),
-				Label:         "Standard Penalty",
-				Value:         -1,
-				VenueSpecific: false,
+				Label:         "Venue Bonus",
+				Value:         1,
+				VenueSpecific: true,
 				Active:        false,
 			},
 		}
@@ -261,7 +261,7 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		assert.Equal(t, "Did you commit any party fouls?", form.GetGroups()[2].GetLabel())
 	})
 
-	t.Run("active flag maps to default value", func(t *testing.T) {
+	t.Run("active adjustments selected by default", func(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
@@ -295,14 +295,19 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		require.True(t, ok)
 
 		opts := smVariant.SelectMany.GetOptions()
-		require.Len(t, opts, 3)
+		require.Len(t, opts, len(adj))
+
+		wantDefaults := make([]bool, len(adj))
+		for i, a := range adj {
+			wantDefaults[i] = a.Active
+		}
 
 		gotDefaults := make([]bool, len(opts))
 		for i, o := range opts {
 			gotDefaults[i] = o.GetDefaultValue()
 		}
 
-		assert.Equal(t, []bool{true, false, true}, gotDefaults)
+		assert.Equal(t, wantDefaults, gotDefaults)
 	})
 }
 
@@ -329,24 +334,30 @@ func TestParseSubmitScoreForm(t *testing.T) {
 		}
 	}
 
+	randSips := func() int64 {
+		return int64(rand.IntN(SubmitScoreSipsMax-SubmitScoreSipsMin+1) + SubmitScoreSipsMin) //nolint:gosec // test-only randomness
+	}
+
 	t.Run("valid score only", func(t *testing.T) {
 		t.Parallel()
 
-		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(3)})
+		sips := randSips()
+		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(sips)})
 		require.NoError(t, err)
-		assert.Equal(t, uint32(3), score)
+		assert.Equal(t, uint32(sips), score) //nolint:gosec // sips is bounded by [SipsMin, SipsMax]
 		assert.Empty(t, adj)
 	})
 
 	t.Run("score with venue adjustments", func(t *testing.T) {
 		t.Parallel()
 
+		sips := randSips()
 		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
-			numericVal(5),
+			numericVal(sips),
 			selectManyVal(SubmitScoreInputIDVenueAdj, []string{id1.String(), id2.String()}),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, uint32(5), score)
+		assert.Equal(t, uint32(sips), score) //nolint:gosec // sips is bounded by [SipsMin, SipsMax]
 		assert.Equal(t, []models.AdjustmentTemplateID{
 			models.AdjustmentTemplateIDFromULID(id1),
 			models.AdjustmentTemplateIDFromULID(id2),
@@ -356,12 +367,13 @@ func TestParseSubmitScoreForm(t *testing.T) {
 	t.Run("score with standard adjustments", func(t *testing.T) {
 		t.Parallel()
 
+		sips := randSips()
 		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
-			numericVal(2),
+			numericVal(sips),
 			selectManyVal(SubmitScoreInputIDStandardAdj, []string{id1.String()}),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, uint32(2), score)
+		assert.Equal(t, uint32(sips), score) //nolint:gosec // sips is bounded by [SipsMin, SipsMax]
 		assert.Equal(t, []models.AdjustmentTemplateID{
 			models.AdjustmentTemplateIDFromULID(id1),
 		}, adj)
@@ -370,13 +382,14 @@ func TestParseSubmitScoreForm(t *testing.T) {
 	t.Run("score with both adjustment types", func(t *testing.T) {
 		t.Parallel()
 
+		sips := randSips()
 		score, adj, err := ParseSubmitScoreForm([]*apiv1.FormValue{
-			numericVal(4),
+			numericVal(sips),
 			selectManyVal(SubmitScoreInputIDVenueAdj, []string{id1.String()}),
 			selectManyVal(SubmitScoreInputIDStandardAdj, []string{id2.String(), id3.String()}),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, uint32(4), score)
+		assert.Equal(t, uint32(sips), score) //nolint:gosec // sips is bounded by [SipsMin, SipsMax]
 		assert.Equal(t, []models.AdjustmentTemplateID{
 			models.AdjustmentTemplateIDFromULID(id1),
 			models.AdjustmentTemplateIDFromULID(id2),

--- a/api/internal/lib/forms/forms_test.go
+++ b/api/internal/lib/forms/forms_test.go
@@ -6,10 +6,17 @@ import (
 	ulid "github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/pubgolf/pubgolf/api/internal/lib/models"
 	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+	"github.com/pubgolf/pubgolf/api/internal/lib/testguard"
 )
+
+func TestMain(m *testing.M) {
+	testguard.UnitTest()
+	goleak.VerifyTestMain(m)
+}
 
 func TestParseFormValueNumeric(t *testing.T) {
 	t.Parallel()

--- a/api/internal/lib/forms/forms_test.go
+++ b/api/internal/lib/forms/forms_test.go
@@ -1,6 +1,7 @@
 package forms
 
 import (
+	"math/rand/v2"
 	"testing"
 
 	ulid "github.com/oklog/ulid/v2"
@@ -141,16 +142,6 @@ func TestParseFormValueSelectMany(t *testing.T) {
 	}
 }
 
-func makeAdjTemplate(id ulid.ULID, label string, value int32, venueSpecific, active bool) models.AdjustmentTemplate {
-	return models.AdjustmentTemplate{
-		ID:            models.AdjustmentTemplateIDFromULID(id),
-		Label:         label,
-		Value:         value,
-		VenueSpecific: venueSpecific,
-		Active:        active,
-	}
-}
-
 func TestGenerateSubmitScoreForm(t *testing.T) {
 	t.Parallel()
 
@@ -170,7 +161,8 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 	t.Run("nonzero score uses edit labels", func(t *testing.T) {
 		t.Parallel()
 
-		form := GenerateSubmitScoreForm(5, nil)
+		score := uint32(rand.IntN(SubmitScoreSipsMax) + 1) //nolint:gosec // test-only randomness
+		form := GenerateSubmitScoreForm(score, nil)
 
 		assert.Equal(t, "Edit Your Score", form.GetLabel())
 		assert.Equal(t, "Re-Submit", form.GetActionLabel())
@@ -192,11 +184,12 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 	t.Run("nonzero score defaults sips to current score", func(t *testing.T) {
 		t.Parallel()
 
-		form := GenerateSubmitScoreForm(5, nil)
+		score := uint32(rand.IntN(SubmitScoreSipsMax) + 1) //nolint:gosec // test-only randomness
+		form := GenerateSubmitScoreForm(score, nil)
 
 		numVariant, ok := form.GetGroups()[0].GetInputs()[0].GetVariant().(*apiv1.FormInput_Numeric)
 		require.True(t, ok)
-		assert.Equal(t, int64(5), numVariant.Numeric.GetDefaultValue())
+		assert.Equal(t, int64(score), numVariant.Numeric.GetDefaultValue())
 	})
 
 	t.Run("nil adjustments produces only sips group", func(t *testing.T) {
@@ -206,11 +199,17 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		require.Len(t, form.GetGroups(), 1)
 	})
 
-	t.Run("venue specific adjustments only", func(t *testing.T) {
+	t.Run("venue specific adjustments get venue label", func(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
-			makeAdjTemplate(id1, "Bonus", 1, true, false),
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id1),
+				Label:         "Bonus",
+				Value:         1,
+				VenueSpecific: true,
+				Active:        false,
+			},
 		}
 
 		form := GenerateSubmitScoreForm(0, adj)
@@ -218,11 +217,17 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		assert.Equal(t, "Venue-Specific Events", form.GetGroups()[1].GetLabel())
 	})
 
-	t.Run("standard adjustments only", func(t *testing.T) {
+	t.Run("standard adjustments get party fouls label", func(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
-			makeAdjTemplate(id1, "Penalty", -1, false, false),
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id1),
+				Label:         "Penalty",
+				Value:         -1,
+				VenueSpecific: false,
+				Active:        false,
+			},
 		}
 
 		form := GenerateSubmitScoreForm(0, adj)
@@ -230,12 +235,24 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		assert.Equal(t, "Did you commit any party fouls?", form.GetGroups()[1].GetLabel())
 	})
 
-	t.Run("both adjustment types", func(t *testing.T) {
+	t.Run("venue and standard adjustments produce separate groups", func(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
-			makeAdjTemplate(id1, "Venue Bonus", 1, true, false),
-			makeAdjTemplate(id2, "Standard Penalty", -1, false, false),
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id1),
+				Label:         "Venue Bonus",
+				Value:         1,
+				VenueSpecific: true,
+				Active:        false,
+			},
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id2),
+				Label:         "Standard Penalty",
+				Value:         -1,
+				VenueSpecific: false,
+				Active:        false,
+			},
 		}
 
 		form := GenerateSubmitScoreForm(0, adj)
@@ -248,9 +265,27 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		t.Parallel()
 
 		adj := []models.AdjustmentTemplate{
-			makeAdjTemplate(id1, "Active", 1, false, true),
-			makeAdjTemplate(id2, "Inactive", -1, false, false),
-			makeAdjTemplate(id3, "Also Active", 2, false, true),
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id1),
+				Label:         "Active",
+				Value:         1,
+				VenueSpecific: false,
+				Active:        true,
+			},
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id2),
+				Label:         "Inactive",
+				Value:         -1,
+				VenueSpecific: false,
+				Active:        false,
+			},
+			{
+				ID:            models.AdjustmentTemplateIDFromULID(id3),
+				Label:         "Also Active",
+				Value:         2,
+				VenueSpecific: false,
+				Active:        true,
+			},
 		}
 
 		form := GenerateSubmitScoreForm(0, adj)
@@ -259,13 +294,15 @@ func TestGenerateSubmitScoreForm(t *testing.T) {
 		smVariant, ok := form.GetGroups()[1].GetInputs()[0].GetVariant().(*apiv1.FormInput_SelectMany)
 		require.True(t, ok)
 
-		selectMany := smVariant.SelectMany
-		opts := selectMany.GetOptions()
+		opts := smVariant.SelectMany.GetOptions()
 		require.Len(t, opts, 3)
 
-		assert.True(t, opts[0].GetDefaultValue())
-		assert.False(t, opts[1].GetDefaultValue())
-		assert.True(t, opts[2].GetDefaultValue())
+		gotDefaults := make([]bool, len(opts))
+		for i, o := range opts {
+			gotDefaults[i] = o.GetDefaultValue()
+		}
+
+		assert.Equal(t, []bool{true, false, true}, gotDefaults)
 	})
 }
 
@@ -310,9 +347,10 @@ func TestParseSubmitScoreForm(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, uint32(5), score)
-		require.Len(t, adj, 2)
-		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id1), adj[0])
-		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id2), adj[1])
+		assert.Equal(t, []models.AdjustmentTemplateID{
+			models.AdjustmentTemplateIDFromULID(id1),
+			models.AdjustmentTemplateIDFromULID(id2),
+		}, adj)
 	})
 
 	t.Run("score with standard adjustments", func(t *testing.T) {
@@ -324,8 +362,9 @@ func TestParseSubmitScoreForm(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, uint32(2), score)
-		require.Len(t, adj, 1)
-		assert.Equal(t, models.AdjustmentTemplateIDFromULID(id1), adj[0])
+		assert.Equal(t, []models.AdjustmentTemplateID{
+			models.AdjustmentTemplateIDFromULID(id1),
+		}, adj)
 	})
 
 	t.Run("score with both adjustment types", func(t *testing.T) {
@@ -338,23 +377,45 @@ func TestParseSubmitScoreForm(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, uint32(4), score)
-		require.Len(t, adj, 3)
+		assert.Equal(t, []models.AdjustmentTemplateID{
+			models.AdjustmentTemplateIDFromULID(id1),
+			models.AdjustmentTemplateIDFromULID(id2),
+			models.AdjustmentTemplateIDFromULID(id3),
+		}, adj)
 	})
 
-	t.Run("boundary min sips", func(t *testing.T) {
+	t.Run("sips boundary values", func(t *testing.T) {
 		t.Parallel()
 
-		score, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(SubmitScoreSipsMin)})
-		require.NoError(t, err)
-		assert.Equal(t, uint32(SubmitScoreSipsMin), score)
-	})
+		tests := []struct {
+			name    string
+			sips    int64
+			want    uint32
+			wantErr error
+		}{
+			{name: "min", sips: SubmitScoreSipsMin, want: uint32(SubmitScoreSipsMin)},
+			{name: "max", sips: SubmitScoreSipsMax, want: uint32(SubmitScoreSipsMax)},
+			{name: "below min", sips: 0, wantErr: ErrInputOutOfAllowedRange},
+			{name: "above max", sips: 11, wantErr: ErrInputOutOfAllowedRange},
+			{name: "negative", sips: -1, wantErr: ErrInputOutOfAllowedRange},
+		}
 
-	t.Run("boundary max sips", func(t *testing.T) {
-		t.Parallel()
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
-		score, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(SubmitScoreSipsMax)})
-		require.NoError(t, err)
-		assert.Equal(t, uint32(SubmitScoreSipsMax), score)
+				score, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(tt.sips)})
+				if tt.wantErr != nil {
+					require.Error(t, err)
+					assert.ErrorIs(t, err, tt.wantErr)
+
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, score)
+			})
+		}
 	})
 
 	t.Run("error missing sips", func(t *testing.T) {
@@ -371,30 +432,6 @@ func TestParseSubmitScoreForm(t *testing.T) {
 		_, _, err := ParseSubmitScoreForm(nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrMissingRequiredInput)
-	})
-
-	t.Run("error sips below min", func(t *testing.T) {
-		t.Parallel()
-
-		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(0)})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
-	})
-
-	t.Run("error sips above max", func(t *testing.T) {
-		t.Parallel()
-
-		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(11)})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
-	})
-
-	t.Run("error sips negative", func(t *testing.T) {
-		t.Parallel()
-
-		_, _, err := ParseSubmitScoreForm([]*apiv1.FormValue{numericVal(-1)})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrInputOutOfAllowedRange)
 	})
 
 	t.Run("error sips wrong variant", func(t *testing.T) {
@@ -429,6 +466,7 @@ func TestParseSubmitScoreForm(t *testing.T) {
 			selectManyVal(SubmitScoreInputIDVenueAdj, []string{"not-a-ulid"}),
 		})
 		require.Error(t, err)
+		assert.ErrorContains(t, err, "parse AdjustmentTemplateID from string")
 	})
 
 	t.Run("nil form value in slice returns error", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `api/internal/lib/forms/` package
- Cover `ParseFormValueNumeric`, `ParseFormValueSelectMany`, `GenerateSubmitScoreForm`, and `ParseSubmitScoreForm`
- 33 tests covering happy paths, boundary values, error conditions, and variant mismatches

## Test plan
- [x] `pubgolf-devctrl check go` passes with 0 lint issues
- [x] `go test ./api/internal/lib/forms/...` — all 33 tests pass
- [x] No files modified outside test scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)