### PR TITLE
Add context error interceptor and cancellation tests

### DIFF
--- a/api/internal/lib/middleware/context_error.go
+++ b/api/internal/lib/middleware/context_error.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// NewContextErrorInterceptor remaps Connect error codes when the underlying
+// error wraps a context cancellation or deadline exceeded error. This allows
+// handlers and guards to uniformly wrap errors as CodeUnavailable without
+// needing to special-case context errors — the interceptor corrects the code
+// to CodeCanceled or CodeDeadlineExceeded before the response reaches OTel
+// and logging interceptors.
+func NewContextErrorInterceptor() connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			resp, err := next(ctx, req)
+			if err == nil {
+				return resp, nil
+			}
+
+			var connectErr *connect.Error
+			if !errors.As(err, &connectErr) {
+				return resp, err
+			}
+
+			// Check DeadlineExceeded first: a deadline expiration also cancels
+			// the context, so both context.Canceled and context.DeadlineExceeded
+			// may be present.
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil, connect.NewError(connect.CodeDeadlineExceeded, connectErr.Unwrap())
+			}
+
+			if errors.Is(err, context.Canceled) {
+				return nil, connect.NewError(connect.CodeCanceled, connectErr.Unwrap())
+			}
+
+			return resp, err
+		})
+	}
+
+	return connect.UnaryInterceptorFunc(interceptor)
+}

--- a/api/internal/lib/middleware/context_error_test.go
+++ b/api/internal/lib/middleware/context_error_test.go
@@ -1,0 +1,123 @@
+package middleware
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/testguard"
+)
+
+func TestMain(m *testing.M) {
+	testguard.UnitTest()
+	goleak.VerifyTestMain(m,
+		// dao package initializes expirable LRU caches at package level; their eviction
+		// goroutines run for the lifetime of the process and can't be stopped.
+		goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
+	)
+}
+
+func TestContextErrorInterceptor(t *testing.T) {
+	t.Parallel()
+
+	interceptor := NewContextErrorInterceptor()
+
+	makeHandler := func(err error) connect.UnaryFunc {
+		return func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			return nil, err
+		}
+	}
+
+	t.Run("remaps CodeUnavailable to CodeCanceled for context.Canceled", func(t *testing.T) {
+		t.Parallel()
+
+		handlerErr := connect.NewError(connect.CodeUnavailable, fmt.Errorf("get event ID from database: %w", context.Canceled))
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeCanceled, connect.CodeOf(err))
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("remaps CodeUnavailable to CodeDeadlineExceeded for context.DeadlineExceeded", func(t *testing.T) {
+		t.Parallel()
+
+		handlerErr := connect.NewError(connect.CodeUnavailable, fmt.Errorf("check event registration: %w", context.DeadlineExceeded))
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeDeadlineExceeded, connect.CodeOf(err))
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("remaps CodeUnknown to CodeCanceled for context.Canceled", func(t *testing.T) {
+		t.Parallel()
+
+		handlerErr := connect.NewError(connect.CodeUnknown, fmt.Errorf("insert score: %w", context.Canceled))
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeCanceled, connect.CodeOf(err))
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("does not remap non-context errors", func(t *testing.T) {
+		t.Parallel()
+
+		handlerErr := connect.NewError(connect.CodeUnavailable, fmt.Errorf("lookup stage ID: %w", sql.ErrNoRows))
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	})
+
+	t.Run("passes through nil errors", func(t *testing.T) {
+		t.Parallel()
+
+		handler := interceptor(makeHandler(nil))
+
+		_, err := handler(t.Context(), nil)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("passes through non-connect errors", func(t *testing.T) {
+		t.Parallel()
+
+		handlerErr := fmt.Errorf("raw error: %w", context.Canceled)
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		// Raw errors pass through unchanged — Connect's built-in wrapIfContextError handles them
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("preserves wrapped error message", func(t *testing.T) {
+		t.Parallel()
+
+		innerMsg := "get event ID from database: context canceled"
+		handlerErr := connect.NewError(connect.CodeUnavailable, fmt.Errorf("%s: %w", "get event ID from database", context.Canceled))
+		handler := interceptor(makeHandler(handlerErr))
+
+		_, err := handler(t.Context(), nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), innerMsg)
+	})
+}

--- a/api/internal/lib/middleware/middleware.go
+++ b/api/internal/lib/middleware/middleware.go
@@ -23,6 +23,7 @@ func ConnectInterceptors() ([]connect.Interceptor, error) {
 	return []connect.Interceptor{
 		otel,
 		NewLoggingInterceptor(),
+		NewContextErrorInterceptor(),
 		NewRecoveringInterceptor(),
 	}, nil
 }

--- a/api/internal/lib/rpc/public/context_cancellation_test.go
+++ b/api/internal/lib/rpc/public/context_cancellation_test.go
@@ -1,0 +1,250 @@
+package public
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
+	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
+	"github.com/pubgolf/pubgolf/api/internal/lib/models"
+	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
+)
+
+func TestGetSchedule_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when context is already cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a pre-cancelled context
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+
+		m := new(dao.MockQueryProvider)
+		// EventIDByKey should propagate the context cancellation
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				models.EventID{},
+				context.Canceled,
+			},
+		}.Bind(m, "EventIDByKey")
+
+		server := makeTestServer(m)
+
+		_, err := server.GetSchedule(ctx, connect.NewRequest(&apiv1.GetScheduleRequest{
+			EventKey: "test-event",
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	})
+}
+
+func TestSubmitScore_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when context is cancelled during EventIDByKey call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a pre-cancelled context
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+
+		m := new(dao.MockQueryProvider)
+		// EventIDByKey should propagate the context cancellation
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				models.EventID{},
+				context.Canceled,
+			},
+		}.Bind(m, "EventIDByKey")
+
+		server := makeTestServer(m)
+
+		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			EventKey: "test-event",
+			VenueKey: 1,
+			PlayerId: playerID.String(),
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	})
+
+	t.Run("returns error when context is cancelled during PlayerRegisteredForEvent call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a pre-cancelled context
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+		eventID := models.EventIDFromULID(ulid.Make())
+
+		m := new(dao.MockQueryProvider)
+
+		// EventIDByKey succeeds
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				eventID,
+				nil,
+			},
+		}.Bind(m, "EventIDByKey")
+
+		// PlayerRegisteredForEvent propagates context cancellation
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				false,
+				context.Canceled,
+			},
+		}.Bind(m, "PlayerRegisteredForEvent")
+
+		server := makeTestServer(m)
+
+		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			EventKey: "test-event",
+			VenueKey: 1,
+			PlayerId: playerID.String(),
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	})
+
+	t.Run("returns error when context is cancelled during StageIDByVenueKey call", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a pre-cancelled context
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+		eventID := models.EventIDFromULID(ulid.Make())
+
+		m := new(dao.MockQueryProvider)
+
+		// EventIDByKey succeeds
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				eventID,
+				nil,
+			},
+		}.Bind(m, "EventIDByKey")
+
+		// PlayerRegisteredForEvent succeeds
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				true,
+				nil,
+			},
+		}.Bind(m, "PlayerRegisteredForEvent")
+
+		// StageIDByVenueKey propagates context cancellation
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				models.StageID{},
+				context.Canceled,
+			},
+		}.Bind(m, "StageIDByVenueKey")
+
+		server := makeTestServer(m)
+
+		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
+			EventKey: "test-event",
+			VenueKey: 1,
+			PlayerId: playerID.String(),
+		}))
+
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	})
+}
+
+func TestGetSchedule_ContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error when context has exceeded deadline", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a context with an already-passed deadline
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		playerID := models.PlayerIDFromULID(ulid.Make())
+		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+
+		m := new(dao.MockQueryProvider)
+		// EventIDByKey should propagate the deadline exceeded error
+		dao.MockDAOCall{
+			ShouldCall: true,
+			Args: []any{
+				mock.Anything,
+				mock.Anything,
+			},
+			Return: []any{
+				models.EventID{},
+				context.Canceled,
+			},
+		}.Bind(m, "EventIDByKey")
+
+		server := makeTestServer(m)
+
+		_, err := server.GetSchedule(ctx, connect.NewRequest(&apiv1.GetScheduleRequest{
+			EventKey: "test-event",
+		}))
+
+		assert.Error(t, err)
+	})
+}

--- a/api/internal/lib/rpc/public/context_cancellation_test.go
+++ b/api/internal/lib/rpc/public/context_cancellation_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -89,7 +88,6 @@ func TestGuardRegisteredForEvent_ContextErrors(t *testing.T) {
 				_, err := s.guardRegisteredForEvent(ce.makeCtx(t), playerID, eventKey)
 
 				require.Error(t, err)
-				assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 				assert.ErrorIs(t, err, ce.ctxErr)
 			})
 
@@ -104,7 +102,6 @@ func TestGuardRegisteredForEvent_ContextErrors(t *testing.T) {
 				_, err := s.guardRegisteredForEvent(ce.makeCtx(t), playerID, eventKey)
 
 				require.Error(t, err)
-				assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 				assert.ErrorIs(t, err, ce.ctxErr)
 			})
 		})
@@ -128,7 +125,6 @@ func TestGuardStageID_ContextErrors(t *testing.T) {
 			_, err := s.guardStageID(ce.makeCtx(t), eventID, venueKey)
 
 			require.Error(t, err)
-			assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 			assert.ErrorIs(t, err, ce.ctxErr)
 		})
 	}
@@ -151,7 +147,6 @@ func TestGuardPlayerCategory_ContextErrors(t *testing.T) {
 			_, err := s.guardPlayerCategory(ce.makeCtx(t), playerID, eventID)
 
 			require.Error(t, err)
-			assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 			assert.ErrorIs(t, err, ce.ctxErr)
 		})
 	}

--- a/api/internal/lib/rpc/public/context_cancellation_test.go
+++ b/api/internal/lib/rpc/public/context_cancellation_test.go
@@ -3,6 +3,7 @@ package public
 import (
 	"context"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
@@ -11,240 +12,147 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pubgolf/pubgolf/api/internal/lib/dao"
-	"github.com/pubgolf/pubgolf/api/internal/lib/middleware"
 	"github.com/pubgolf/pubgolf/api/internal/lib/models"
-	apiv1 "github.com/pubgolf/pubgolf/api/internal/lib/proto/api/v1"
 )
 
-func TestGetSchedule_ContextCancellation(t *testing.T) {
-	t.Parallel()
+// mockDAOCallWithError sets up a DAO mock method to return the given error with
+// a zero-value result. argCount specifies the number of arguments (all matched
+// with mock.Anything).
+func mockDAOCallWithError(m *dao.MockQueryProvider, method string, zeroVal any, ctxErr error, argCount int) {
+	args := make([]any, argCount)
+	for i := range args {
+		args[i] = mock.Anything
+	}
 
-	t.Run("returns error when context is already cancelled", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a pre-cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		playerID := models.PlayerIDFromULID(ulid.Make())
-		ctx = middleware.ContextWithPlayerID(ctx, playerID)
-
-		m := new(dao.MockQueryProvider)
-		// EventIDByKey should propagate the context cancellation
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				models.EventID{},
-				context.Canceled,
-			},
-		}.Bind(m, "EventIDByKey")
-
-		server := makeTestServer(m)
-
-		_, err := server.GetSchedule(ctx, connect.NewRequest(&apiv1.GetScheduleRequest{
-			EventKey: "test-event",
-		}))
-
-		require.Error(t, err)
-		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
-	})
+	dao.MockDAOCall{
+		ShouldCall: true,
+		Args:       args,
+		Return:     []any{zeroVal, ctxErr},
+	}.Bind(m, method)
 }
 
-func TestSubmitScore_ContextCancellation(t *testing.T) {
-	t.Parallel()
+// contextErrorCases returns table-driven test cases for both flavors of context
+// error: a pre-canceled context and an already-expired deadline.
+func contextErrorCases() []struct {
+	name    string
+	makeCtx func(t *testing.T) context.Context
+	ctxErr  error
+} {
+	return []struct {
+		name    string
+		makeCtx func(t *testing.T) context.Context
+		ctxErr  error
+	}{
+		{
+			name: "canceled context",
+			makeCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
 
-	t.Run("returns error when context is cancelled during EventIDByKey call", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a pre-cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		playerID := models.PlayerIDFromULID(ulid.Make())
-		ctx = middleware.ContextWithPlayerID(ctx, playerID)
-
-		m := new(dao.MockQueryProvider)
-		// EventIDByKey should propagate the context cancellation
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
+				return ctx
 			},
-			Return: []any{
-				models.EventID{},
-				context.Canceled,
+			ctxErr: context.Canceled,
+		},
+		{
+			name: "expired deadline",
+			makeCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+
+				return ctx
 			},
-		}.Bind(m, "EventIDByKey")
-
-		server := makeTestServer(m)
-
-		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
-			EventKey: "test-event",
-			VenueKey: 1,
-			PlayerId: playerID.String(),
-		}))
-
-		require.Error(t, err)
-		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
-	})
-
-	t.Run("returns error when context is cancelled during PlayerRegisteredForEvent call", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a pre-cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		playerID := models.PlayerIDFromULID(ulid.Make())
-		ctx = middleware.ContextWithPlayerID(ctx, playerID)
-		eventID := models.EventIDFromULID(ulid.Make())
-
-		m := new(dao.MockQueryProvider)
-
-		// EventIDByKey succeeds
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				eventID,
-				nil,
-			},
-		}.Bind(m, "EventIDByKey")
-
-		// PlayerRegisteredForEvent propagates context cancellation
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				false,
-				context.Canceled,
-			},
-		}.Bind(m, "PlayerRegisteredForEvent")
-
-		server := makeTestServer(m)
-
-		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
-			EventKey: "test-event",
-			VenueKey: 1,
-			PlayerId: playerID.String(),
-		}))
-
-		require.Error(t, err)
-		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
-	})
-
-	t.Run("returns error when context is cancelled during StageIDByVenueKey call", func(t *testing.T) {
-		t.Parallel()
-
-		// Create a pre-cancelled context
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
-
-		playerID := models.PlayerIDFromULID(ulid.Make())
-		ctx = middleware.ContextWithPlayerID(ctx, playerID)
-		eventID := models.EventIDFromULID(ulid.Make())
-
-		m := new(dao.MockQueryProvider)
-
-		// EventIDByKey succeeds
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				eventID,
-				nil,
-			},
-		}.Bind(m, "EventIDByKey")
-
-		// PlayerRegisteredForEvent succeeds
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				true,
-				nil,
-			},
-		}.Bind(m, "PlayerRegisteredForEvent")
-
-		// StageIDByVenueKey propagates context cancellation
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				models.StageID{},
-				context.Canceled,
-			},
-		}.Bind(m, "StageIDByVenueKey")
-
-		server := makeTestServer(m)
-
-		_, err := server.SubmitScore(ctx, connect.NewRequest(&apiv1.SubmitScoreRequest{
-			EventKey: "test-event",
-			VenueKey: 1,
-			PlayerId: playerID.String(),
-		}))
-
-		require.Error(t, err)
-		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
-	})
+			ctxErr: context.DeadlineExceeded,
+		},
+	}
 }
 
-func TestGetSchedule_ContextDeadline(t *testing.T) {
+func TestGuardRegisteredForEvent_ContextErrors(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns error when context has exceeded deadline", func(t *testing.T) {
-		t.Parallel()
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	eventID := models.EventIDFromULID(ulid.Make())
+	eventKey := "test-event"
 
-		// Create a context with an already-passed deadline
-		ctx, cancel := context.WithCancel(t.Context())
-		cancel()
+	for _, ce := range contextErrorCases() {
+		t.Run(ce.name, func(t *testing.T) {
+			t.Parallel()
 
-		playerID := models.PlayerIDFromULID(ulid.Make())
-		ctx = middleware.ContextWithPlayerID(ctx, playerID)
+			t.Run("propagates from EventIDByKey", func(t *testing.T) {
+				t.Parallel()
 
-		m := new(dao.MockQueryProvider)
-		// EventIDByKey should propagate the deadline exceeded error
-		dao.MockDAOCall{
-			ShouldCall: true,
-			Args: []any{
-				mock.Anything,
-				mock.Anything,
-			},
-			Return: []any{
-				models.EventID{},
-				context.Canceled,
-			},
-		}.Bind(m, "EventIDByKey")
+				m := new(dao.MockQueryProvider)
+				mockDAOCallWithError(m, "EventIDByKey", models.EventID{}, ce.ctxErr, 2)
+				s := makeTestServer(m)
 
-		server := makeTestServer(m)
+				_, err := s.guardRegisteredForEvent(ce.makeCtx(t), playerID, eventKey)
 
-		_, err := server.GetSchedule(ctx, connect.NewRequest(&apiv1.GetScheduleRequest{
-			EventKey: "test-event",
-		}))
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+				assert.ErrorIs(t, err, ce.ctxErr)
+			})
 
-		assert.Error(t, err)
-	})
+			t.Run("propagates from PlayerRegisteredForEvent mid-request", func(t *testing.T) {
+				t.Parallel()
+
+				m := new(dao.MockQueryProvider)
+				mockEventIDByKey(m, eventKey, eventID)
+				mockDAOCallWithError(m, "PlayerRegisteredForEvent", false, ce.ctxErr, 3)
+				s := makeTestServer(m)
+
+				_, err := s.guardRegisteredForEvent(ce.makeCtx(t), playerID, eventKey)
+
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+				assert.ErrorIs(t, err, ce.ctxErr)
+			})
+		})
+	}
+}
+
+func TestGuardStageID_ContextErrors(t *testing.T) {
+	t.Parallel()
+
+	eventID := models.EventIDFromULID(ulid.Make())
+	venueKey := models.VenueKeyFromUInt32(1)
+
+	for _, ce := range contextErrorCases() {
+		t.Run(ce.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := new(dao.MockQueryProvider)
+			mockDAOCallWithError(m, "StageIDByVenueKey", models.StageID{}, ce.ctxErr, 3)
+			s := makeTestServer(m)
+
+			_, err := s.guardStageID(ce.makeCtx(t), eventID, venueKey)
+
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+			assert.ErrorIs(t, err, ce.ctxErr)
+		})
+	}
+}
+
+func TestGuardPlayerCategory_ContextErrors(t *testing.T) {
+	t.Parallel()
+
+	playerID := models.PlayerIDFromULID(ulid.Make())
+	eventID := models.EventIDFromULID(ulid.Make())
+
+	for _, ce := range contextErrorCases() {
+		t.Run(ce.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := new(dao.MockQueryProvider)
+			mockDAOCallWithError(m, "PlayerCategoryForEvent", models.ScoringCategoryUnspecified, ce.ctxErr, 3)
+			s := makeTestServer(m)
+
+			_, err := s.guardPlayerCategory(ce.makeCtx(t), playerID, eventID)
+
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+			assert.ErrorIs(t, err, ce.ctxErr)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Adds a Connect interceptor (`NewContextErrorInterceptor`) that remaps error codes when the underlying error wraps `context.Canceled` → `CodeCanceled` or `context.DeadlineExceeded` → `CodeDeadlineExceeded`
- Handlers and guards can uniformly wrap errors as `CodeUnavailable` without special-casing context errors — the interceptor corrects the code centrally
- Registered above the panic recoverer but below OTel/logging so telemetry reflects the codes actually returned to clients
- Guard-level context cancellation tests verify error propagation through `guardRegisteredForEvent`, `guardStageID`, and `guardPlayerCategory` with both canceled and deadline-exceeded contexts
- Interceptor tests verify code remapping, passthrough for non-context errors, and error message preservation

## Test plan
- [x] `pubgolf-devctrl check go` passes
- [x] `pubgolf-devctrl test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)