### PR TITLE
feat(devctrl): add build web command

### DIFF
--- a/tools/lib/cmd/build.go
+++ b/tools/lib/cmd/build.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	buildCmd.AddCommand(buildWebCmd)
+	rootCmd.AddCommand(buildCmd)
+}
+
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build all targets",
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(buildWeb(cmd.Context(), runner))
+	},
+}
+
+var buildWebCmd = &cobra.Command{
+	Use:   "web",
+	Short: "Build the web app with Vite",
+	Run: func(cmd *cobra.Command, _ []string) {
+		classifyAndExit(buildWeb(cmd.Context(), runner))
+	},
+}
+
+func buildWeb(ctx context.Context, r Runner) error {
+	err := r.Run(ctx, Cmd{
+		Name: filepath.FromSlash("./node_modules/.bin/vite"),
+		Args: []string{"build"},
+		Dir:  "web-app",
+	})
+	if err != nil {
+		return fmtErr(err, "build web-app")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- New `build` command group with `build web` subcommand
- Runs `vite build` directly via `node_modules/.bin`
- Bare `build` delegates to `buildWeb` as the sole target

Part of devctrl web commands (dex task h8ndsxtb)

## Test plan
- [x] `go build ./tools/cmd/pubgolf-devctrl` compiles
- [x] `go vet ./tools/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)