### PR TITLE
feat(devctrl): add run web subcommand for SvelteKit dev server

### DIFF
--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -15,6 +15,7 @@ func init() {
 	runCmd.AddCommand(runAPIBgCmd)
 	runCmd.AddCommand(runAPIDatabaseCmd)
 	// runCmd.AddCommand(runAPIMinioCmd)
+	runCmd.AddCommand(runWebCmd)
 	rootCmd.AddCommand(runCmd)
 
 	runAPIServerCmd.PersistentFlags().Bool("watch", false, "Watch the input directory and automatically restart the server.")
@@ -58,6 +59,26 @@ var runAPIDatabaseCmd = &cobra.Command{
 	Short: "Run API server's DB instance",
 	Run: func(cmd *cobra.Command, _ []string) {
 		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName, "api-db"))
+	},
+}
+
+var runWebCmd = &cobra.Command{
+	Use:   "web",
+	Short: "Run SvelteKit dev server",
+	Run: func(cmd *cobra.Command, _ []string) {
+		env, err := envProvider.Env(cmd.Context(), "web-app", "dev")
+		classifyAndExit(fmtErr(err, "fetch web-app environment"))
+
+		proc, startErr := runner.Start(cmd.Context(), Cmd{
+			Name: filepath.FromSlash("./node_modules/.bin/vite"),
+			Args: []string{"dev"},
+			Dir:  "web-app",
+			Env:  env,
+		})
+		classifyAndExit(fmtErr(startErr, "start vite dev server"))
+
+		<-shuttingDown
+		proc.Stop()
 	},
 }
 


### PR DESCRIPTION
## Summary
- Adds `run web` subcommand that starts Vite dev server (port 5173)
- Fetches env from Doppler project `web-app`, config `dev`
- Complement to `run api` — user runs both in separate terminals
- Uses `Runner.Start()` + `shuttingDown` lifecycle pattern

Part of devctrl web commands (dex task hs9svjzy)

## Test plan
- [x] `go build ./tools/cmd/pubgolf-devctrl` compiles
- [x] `go vet ./tools/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)