### PR TITLE
feat(devctrl): redesign bare run for full-stack dev environment

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -117,28 +117,17 @@ Each function passed to `runPar` must have the signature
 ## Function Signatures
 
 **Rule of thumb: 4 parameters max** (not counting `ctx context.Context`). When a
-function needs more than 4 params, group the extras into an options/args struct:
+function exceeds this, simplify in order of preference:
 
-```go
-// Bad: 6 parameters — hard to read, easy to swap strings
-func startServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) error
+1. **Eliminate redundant params** — if every caller passes the same value (e.g.
+   `config.ServerBinName`), read it from the package-level `config` directly.
+   Config is static and doesn't need to be injected for testability.
+2. **Group into an opts struct** — last resort. Structs trade compile-time
+   completeness (missing positional param = compiler error) for readability.
+   Only worth it when params genuinely vary across callers.
 
-// Good: struct groups related config
-type ServerOpts struct {
-    Runner      Runner
-    EnvProvider EnvProvider
-    Project     string
-    EnvCfg      string
-    Bin         string
-    Args        []string
-}
-
-func startServer(ctx context.Context, opts ServerOpts) error
-```
-
-Interfaces (`Runner`, `EnvProvider`) and `context.Context` are fine as direct
-params — they represent cross-cutting concerns, not configuration. The struct
-is for the rest.
+`Runner` and `EnvProvider` stay as direct params — they're swapped in tests
+(`DryRunner`, mock providers) so they must be injectable.
 
 ## nolint Annotations
 

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -114,6 +114,32 @@ Each function passed to `runPar` must have the signature
 - Handler functions: `verbNoun` (e.g. `checkGo`, `generateProto`, `dockerRun`).
 - Cobra vars: `{group}Cmd`, `{group}{Sub}Cmd` (e.g. `checkCmd`, `checkGoCmd`).
 
+## Function Signatures
+
+**Rule of thumb: 4 parameters max** (not counting `ctx context.Context`). When a
+function needs more than 4 params, group the extras into an options/args struct:
+
+```go
+// Bad: 6 parameters — hard to read, easy to swap strings
+func startServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) error
+
+// Good: struct groups related config
+type ServerOpts struct {
+    Runner      Runner
+    EnvProvider EnvProvider
+    Project     string
+    EnvCfg      string
+    Bin         string
+    Args        []string
+}
+
+func startServer(ctx context.Context, opts ServerOpts) error
+```
+
+Interfaces (`Runner`, `EnvProvider`) and `context.Context` are fine as direct
+params — they represent cross-cutting concerns, not configuration. The struct
+is for the rest.
+
 ## nolint Annotations
 
 - `//nolint:ireturn` — on functions that return an interface by design (Runner, Process, EnvProvider).

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -57,9 +57,7 @@ func runFullStack(ctx context.Context, r Runner, ep EnvProvider, args []string) 
 		return fmtErr(err, "start vite preview server")
 	}
 
-	binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-
-	apiProc, err := startAPIServer(ctx, r, ep, config.ServerBinName, config.DopplerEnvName, binPath, args,
+	apiProc, err := startAPIServer(ctx, r, ep, args,
 		fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort),
 	)
 	if err != nil {
@@ -90,8 +88,7 @@ var runAPIServerCmd = &cobra.Command{
 	Use:   "api",
 	Short: "Run API server",
 	Run: func(cmd *cobra.Command, args []string) {
-		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
+		watchableGoRun(cmd, runner, envProvider, args)
 	},
 }
 
@@ -189,15 +186,13 @@ func dockerRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg st
 	return nil
 }
 
-func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) {
+func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, args []string) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
 	classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-	// Start initial process
-	proc := startGoRun(cmd.Context(), r, ep, project, envCfg, bin, args)
+	proc := startGoRun(cmd.Context(), r, ep, args)
 
 	if !watchFlag {
-		// Wait for process to exit, then shut down.
 		waitErr := proc.Wait()
 		if waitErr != nil {
 			log.Printf("process exited with error: %v", waitErr)
@@ -206,30 +201,28 @@ func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCf
 		return
 	}
 
-	// Launch watcher to restart the process on file changes.
 	go func() {
 		watch("api", "restart API server", func(_ watcher.Event) {
 			proc.Stop()
-			proc = startGoRun(context.Background(), r, ep, project, envCfg, bin, args)
+			proc = startGoRun(context.Background(), r, ep, args)
 		})
 	}()
 
-	// Hold process open until shutdown signal.
 	<-shuttingDown
 	proc.Stop()
 }
 
 //nolint:ireturn // Returns Process interface by design.
-func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process {
-	proc, err := startAPIServer(ctx, r, ep, project, envCfg, bin, args)
+func startGoRun(ctx context.Context, r Runner, ep EnvProvider, args []string) Process {
+	proc, err := startAPIServer(ctx, r, ep, args)
 	classifyAndExit(err)
 
 	return proc
 }
 
 //nolint:ireturn // Returns Process interface by design.
-func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string, extraEnv ...string) (Process, error) {
-	env, err := ep.Env(ctx, project, envCfg)
+func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, args []string, extraEnv ...string) (Process, error) {
+	env, err := ep.Env(ctx, config.ServerBinName, config.DopplerEnvName)
 	if err != nil {
 		return nil, fmtErr(err, "fetch go run environment")
 	}
@@ -245,9 +238,10 @@ func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envC
 	)
 	env = append(env, extraEnv...)
 
+	bin := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
 	allArgs := append([]string{"run", bin}, args...)
 
-	log.Printf("Starting '%s'...\n", bin)
+	log.Printf("Starting '%s'...\n", config.ServerBinName)
 
 	proc, err := r.Start(ctx, Cmd{
 		Name: "go",

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -57,11 +57,15 @@ func runFullStack(ctx context.Context, r Runner, ep EnvProvider, args []string) 
 		return fmtErr(err, "start vite preview server")
 	}
 
-	binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-
-	apiProc, err := startAPIServer(ctx, r, ep, config.ServerBinName, config.DopplerEnvName, binPath, args,
-		fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort),
-	)
+	apiProc, err := startAPIServer(ctx, APIServerOpts{
+		Runner:      r,
+		EnvProvider: ep,
+		Project:     config.ServerBinName,
+		EnvCfg:      config.DopplerEnvName,
+		Bin:         filepath.FromSlash("./api/cmd/" + config.ServerBinName),
+		Args:        args,
+		ExtraEnv:    []string{fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort)},
+	})
 	if err != nil {
 		previewProc.Stop()
 
@@ -90,8 +94,14 @@ var runAPIServerCmd = &cobra.Command{
 	Use:   "api",
 	Short: "Run API server",
 	Run: func(cmd *cobra.Command, args []string) {
-		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
+		watchableGoRun(cmd, APIServerOpts{
+			Runner:      runner,
+			EnvProvider: envProvider,
+			Project:     config.ServerBinName,
+			EnvCfg:      config.DopplerEnvName,
+			Bin:         filepath.FromSlash("./api/cmd/" + config.ServerBinName),
+			Args:        args,
+		})
 	},
 }
 
@@ -189,15 +199,13 @@ func dockerRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg st
 	return nil
 }
 
-func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) {
+func watchableGoRun(cmd *cobra.Command, opts APIServerOpts) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
 	classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-	// Start initial process
-	proc := startGoRun(cmd.Context(), r, ep, project, envCfg, bin, args)
+	proc := startGoRun(cmd.Context(), opts)
 
 	if !watchFlag {
-		// Wait for process to exit, then shut down.
 		waitErr := proc.Wait()
 		if waitErr != nil {
 			log.Printf("process exited with error: %v", waitErr)
@@ -206,30 +214,39 @@ func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCf
 		return
 	}
 
-	// Launch watcher to restart the process on file changes.
 	go func() {
 		watch("api", "restart API server", func(_ watcher.Event) {
 			proc.Stop()
-			proc = startGoRun(context.Background(), r, ep, project, envCfg, bin, args)
+			proc = startGoRun(context.Background(), opts)
 		})
 	}()
 
-	// Hold process open until shutdown signal.
 	<-shuttingDown
 	proc.Stop()
 }
 
+// APIServerOpts configures an API server process.
+type APIServerOpts struct {
+	Runner      Runner
+	EnvProvider EnvProvider
+	Project     string
+	EnvCfg      string
+	Bin         string
+	Args        []string
+	ExtraEnv    []string
+}
+
 //nolint:ireturn // Returns Process interface by design.
-func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process {
-	proc, err := startAPIServer(ctx, r, ep, project, envCfg, bin, args)
+func startGoRun(ctx context.Context, opts APIServerOpts) Process {
+	proc, err := startAPIServer(ctx, opts)
 	classifyAndExit(err)
 
 	return proc
 }
 
 //nolint:ireturn // Returns Process interface by design.
-func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string, extraEnv ...string) (Process, error) {
-	env, err := ep.Env(ctx, project, envCfg)
+func startAPIServer(ctx context.Context, opts APIServerOpts) (Process, error) {
+	env, err := opts.EnvProvider.Env(ctx, opts.Project, opts.EnvCfg)
 	if err != nil {
 		return nil, fmtErr(err, "fetch go run environment")
 	}
@@ -243,13 +260,13 @@ func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envC
 		fmt.Sprintf("PUBGOLF_DB_PORT=%d", 5432+offset),
 		fmt.Sprintf("PUBGOLF_PORT=%d", 5000+offset),
 	)
-	env = append(env, extraEnv...)
+	env = append(env, opts.ExtraEnv...)
 
-	allArgs := append([]string{"run", bin}, args...)
+	allArgs := append([]string{"run", opts.Bin}, opts.Args...)
 
-	log.Printf("Starting '%s'...\n", bin)
+	log.Printf("Starting '%s'...\n", opts.Bin)
 
-	proc, err := r.Start(ctx, Cmd{
+	proc, err := opts.Runner.Start(ctx, Cmd{
 		Name: "go",
 		Args: allArgs,
 		Env:  env,

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strconv"
 
 	"github.com/radovskyb/watcher"
 	"github.com/spf13/cobra"
@@ -23,15 +24,66 @@ func init() {
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Run all server executables",
+	Short: "Run full-stack development environment",
 	Run: func(cmd *cobra.Command, args []string) {
-		classifyAndExit(dockerRun(cmd.Context(), runner, envProvider, config.ServerBinName, config.DopplerEnvName,
-			"api-db",
-		))
-
-		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
-		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
+		classifyAndExit(runFullStack(cmd.Context(), runner, envProvider, args))
 	},
+}
+
+func runFullStack(ctx context.Context, r Runner, ep EnvProvider, args []string) error {
+	err := dockerRun(ctx, r, ep, config.ServerBinName, config.DopplerEnvName, "api-db")
+	if err != nil {
+		return err
+	}
+
+	err = buildWeb(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	offset, err := worktreePortOffset(ctx)
+	if err != nil {
+		return fmtErr(err, "compute port offset")
+	}
+
+	previewPort := 4173 + offset
+
+	previewProc, err := r.Start(ctx, Cmd{
+		Name: filepath.FromSlash("./node_modules/.bin/vite"),
+		Args: []string{"preview", "--port", strconv.Itoa(previewPort)},
+		Dir:  "web-app",
+	})
+	if err != nil {
+		return fmtErr(err, "start vite preview server")
+	}
+
+	binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
+
+	apiProc, err := startAPIServer(ctx, r, ep, config.ServerBinName, config.DopplerEnvName, binPath, args,
+		fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort),
+	)
+	if err != nil {
+		previewProc.Stop()
+
+		return err
+	}
+
+	log.Printf("Full-stack environment running (preview: :%d, API: :%d)\n", previewPort, 5000+offset)
+
+	go func() {
+		<-shuttingDown
+		apiProc.Stop()
+		previewProc.Stop()
+	}()
+
+	waitErr := apiProc.Wait()
+	if waitErr != nil {
+		log.Printf("API server exited with error: %v", waitErr)
+	}
+
+	previewProc.Stop()
+
+	return nil
 }
 
 var runAPIServerCmd = &cobra.Command{
@@ -169,27 +221,42 @@ func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCf
 
 //nolint:ireturn // Returns Process interface by design.
 func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process {
-	env, err := ep.Env(ctx, project, envCfg)
-	classifyAndExit(fmtErr(err, "fetch go run environment"))
+	proc, err := startAPIServer(ctx, r, ep, project, envCfg, bin, args)
+	classifyAndExit(err)
 
-	offset, offsetErr := worktreePortOffset(ctx)
-	classifyAndExit(fmtErr(offsetErr, "compute port offset"))
+	return proc
+}
+
+//nolint:ireturn // Returns Process interface by design.
+func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string, extraEnv ...string) (Process, error) {
+	env, err := ep.Env(ctx, project, envCfg)
+	if err != nil {
+		return nil, fmtErr(err, "fetch go run environment")
+	}
+
+	offset, err := worktreePortOffset(ctx)
+	if err != nil {
+		return nil, fmtErr(err, "compute port offset")
+	}
 
 	env = append(env,
 		fmt.Sprintf("PUBGOLF_DB_PORT=%d", 5432+offset),
 		fmt.Sprintf("PUBGOLF_PORT=%d", 5000+offset),
 	)
+	env = append(env, extraEnv...)
 
 	allArgs := append([]string{"run", bin}, args...)
 
 	log.Printf("Starting '%s'...\n", bin)
 
-	proc, startErr := r.Start(ctx, Cmd{
+	proc, err := r.Start(ctx, Cmd{
 		Name: "go",
 		Args: allArgs,
 		Env:  env,
 	})
-	classifyAndExit(fmtErr(startErr, "execute `go run ...` command"))
+	if err != nil {
+		return nil, fmtErr(err, "start API server")
+	}
 
-	return proc
+	return proc, nil
 }

--- a/tools/lib/cmd/run.go
+++ b/tools/lib/cmd/run.go
@@ -57,15 +57,11 @@ func runFullStack(ctx context.Context, r Runner, ep EnvProvider, args []string) 
 		return fmtErr(err, "start vite preview server")
 	}
 
-	apiProc, err := startAPIServer(ctx, APIServerOpts{
-		Runner:      r,
-		EnvProvider: ep,
-		Project:     config.ServerBinName,
-		EnvCfg:      config.DopplerEnvName,
-		Bin:         filepath.FromSlash("./api/cmd/" + config.ServerBinName),
-		Args:        args,
-		ExtraEnv:    []string{fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort)},
-	})
+	binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
+
+	apiProc, err := startAPIServer(ctx, r, ep, config.ServerBinName, config.DopplerEnvName, binPath, args,
+		fmt.Sprintf("PUBGOLF_WEB_APP_UPSTREAM_HOST=http://localhost:%d", previewPort),
+	)
 	if err != nil {
 		previewProc.Stop()
 
@@ -94,14 +90,8 @@ var runAPIServerCmd = &cobra.Command{
 	Use:   "api",
 	Short: "Run API server",
 	Run: func(cmd *cobra.Command, args []string) {
-		watchableGoRun(cmd, APIServerOpts{
-			Runner:      runner,
-			EnvProvider: envProvider,
-			Project:     config.ServerBinName,
-			EnvCfg:      config.DopplerEnvName,
-			Bin:         filepath.FromSlash("./api/cmd/" + config.ServerBinName),
-			Args:        args,
-		})
+		binPath := filepath.FromSlash("./api/cmd/" + config.ServerBinName)
+		watchableGoRun(cmd, runner, envProvider, config.ServerBinName, config.DopplerEnvName, binPath, args)
 	},
 }
 
@@ -199,13 +189,15 @@ func dockerRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg st
 	return nil
 }
 
-func watchableGoRun(cmd *cobra.Command, opts APIServerOpts) {
+func watchableGoRun(cmd *cobra.Command, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) {
 	watchFlag, err := cmd.Flags().GetBool("watch")
 	classifyAndExit(fmtErr(err, "check '--watch' flag"))
 
-	proc := startGoRun(cmd.Context(), opts)
+	// Start initial process
+	proc := startGoRun(cmd.Context(), r, ep, project, envCfg, bin, args)
 
 	if !watchFlag {
+		// Wait for process to exit, then shut down.
 		waitErr := proc.Wait()
 		if waitErr != nil {
 			log.Printf("process exited with error: %v", waitErr)
@@ -214,39 +206,30 @@ func watchableGoRun(cmd *cobra.Command, opts APIServerOpts) {
 		return
 	}
 
+	// Launch watcher to restart the process on file changes.
 	go func() {
 		watch("api", "restart API server", func(_ watcher.Event) {
 			proc.Stop()
-			proc = startGoRun(context.Background(), opts)
+			proc = startGoRun(context.Background(), r, ep, project, envCfg, bin, args)
 		})
 	}()
 
+	// Hold process open until shutdown signal.
 	<-shuttingDown
 	proc.Stop()
 }
 
-// APIServerOpts configures an API server process.
-type APIServerOpts struct {
-	Runner      Runner
-	EnvProvider EnvProvider
-	Project     string
-	EnvCfg      string
-	Bin         string
-	Args        []string
-	ExtraEnv    []string
-}
-
 //nolint:ireturn // Returns Process interface by design.
-func startGoRun(ctx context.Context, opts APIServerOpts) Process {
-	proc, err := startAPIServer(ctx, opts)
+func startGoRun(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string) Process {
+	proc, err := startAPIServer(ctx, r, ep, project, envCfg, bin, args)
 	classifyAndExit(err)
 
 	return proc
 }
 
 //nolint:ireturn // Returns Process interface by design.
-func startAPIServer(ctx context.Context, opts APIServerOpts) (Process, error) {
-	env, err := opts.EnvProvider.Env(ctx, opts.Project, opts.EnvCfg)
+func startAPIServer(ctx context.Context, r Runner, ep EnvProvider, project, envCfg, bin string, args []string, extraEnv ...string) (Process, error) {
+	env, err := ep.Env(ctx, project, envCfg)
 	if err != nil {
 		return nil, fmtErr(err, "fetch go run environment")
 	}
@@ -260,13 +243,13 @@ func startAPIServer(ctx context.Context, opts APIServerOpts) (Process, error) {
 		fmt.Sprintf("PUBGOLF_DB_PORT=%d", 5432+offset),
 		fmt.Sprintf("PUBGOLF_PORT=%d", 5000+offset),
 	)
-	env = append(env, opts.ExtraEnv...)
+	env = append(env, extraEnv...)
 
-	allArgs := append([]string{"run", opts.Bin}, opts.Args...)
+	allArgs := append([]string{"run", bin}, args...)
 
-	log.Printf("Starting '%s'...\n", opts.Bin)
+	log.Printf("Starting '%s'...\n", bin)
 
-	proc, err := opts.Runner.Start(ctx, Cmd{
+	proc, err := r.Start(ctx, Cmd{
 		Name: "go",
 		Args: allArgs,
 		Env:  env,


### PR DESCRIPTION
## Summary
- Redesigns the bare `pubgolf-devctrl run` command to start the full stack: DB → web build → vite preview → API server
- API is configured with `PUBGOLF_WEB_APP_UPSTREAM_HOST` pointing to the preview server
- Worktree port offsets applied to preview port (4173+offset)

Implements dex task `lk2v493s`.

## Test plan
- [x] `pubgolf-devctrl check go` passes
- [x] `pubgolf-devctrl --dry-run run` shows correct 4-command sequence with proper env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)