### PR TITLE
Use CodeInternal for server-side conversion errors

### DIFF
--- a/api/internal/lib/rpc/admin/create_player.go
+++ b/api/internal/lib/rpc/admin/create_player.go
@@ -53,7 +53,7 @@ func (s *Server) CreatePlayer(ctx context.Context, req *connect.Request[apiv1.Ad
 
 	pp, err := player.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("serialize player: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("serialize player: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.AdminServiceCreatePlayerResponse{

--- a/api/internal/lib/rpc/admin/list_players.go
+++ b/api/internal/lib/rpc/admin/list_players.go
@@ -21,7 +21,7 @@ func (s *Server) ListPlayers(ctx context.Context, req *connect.Request[apiv1.Lis
 	for _, p := range dbPlayers {
 		pp, err := p.Proto()
 		if err != nil {
-			return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 		}
 
 		players = append(players, pp)

--- a/api/internal/lib/rpc/admin/update_player.go
+++ b/api/internal/lib/rpc/admin/update_player.go
@@ -43,7 +43,7 @@ func (s *Server) UpdatePlayer(ctx context.Context, req *connect.Request[apiv1.Up
 
 	up, err := updatedPlayer.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.UpdatePlayerResponse{

--- a/api/internal/lib/rpc/public/complete_player_login.go
+++ b/api/internal/lib/rpc/public/complete_player_login.go
@@ -59,7 +59,7 @@ func (s *Server) CompletePlayerLogin(ctx context.Context, req *connect.Request[a
 
 	p, err := player.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.CompletePlayerLoginResponse{

--- a/api/internal/lib/rpc/public/get_my_player.go
+++ b/api/internal/lib/rpc/public/get_my_player.go
@@ -23,7 +23,7 @@ func (s *Server) GetMyPlayer(ctx context.Context, _ *connect.Request[apiv1.GetMy
 
 	p, err := player.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.GetMyPlayerResponse{

--- a/api/internal/lib/rpc/public/get_player.go
+++ b/api/internal/lib/rpc/public/get_player.go
@@ -23,7 +23,7 @@ func (s *Server) GetPlayer(ctx context.Context, req *connect.Request[apiv1.GetPl
 
 	p, err := player.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.GetPlayerResponse{

--- a/api/internal/lib/rpc/public/get_schedule.go
+++ b/api/internal/lib/rpc/public/get_schedule.go
@@ -57,7 +57,7 @@ func (s *Server) GetSchedule(ctx context.Context, req *connect.Request[apiv1.Get
 
 	hashCode, err := hashstructure.Hash(&schedule, hashstructure.FormatV2, nil)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, err)
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
 	hash := make([]byte, 8)

--- a/api/internal/lib/rpc/public/update_player_data.go
+++ b/api/internal/lib/rpc/public/update_player_data.go
@@ -26,7 +26,7 @@ func (s *Server) UpdatePlayerData(ctx context.Context, req *connect.Request[apiv
 
 	p, err := player.Proto()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("convert player model to proto: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert player model to proto: %w", err))
 	}
 
 	return connect.NewResponse(&apiv1.UpdatePlayerDataResponse{


### PR DESCRIPTION
## Summary
- Replaces `CodeUnknown` with `CodeInternal` for model-to-proto conversion and hash calculation errors
- `CodeInternal` correctly signals server-side invariant violations (serialization bugs)
- 8 error code replacements across 8 handler files (5 public, 3 admin)

## Test plan
- [x] `pubgolf-devctrl check go` passes
- [x] No behavioral changes — only the gRPC error code returned to clients changes

Generated with [Claude Code](https://claude.com/claude-code)