### PR TITLE
ci: cache devctrl binary and node_modules in web app job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,14 +135,33 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Cache devctrl binary
+        id: devctrl-cache
+        uses: actions/cache@v4
+        with:
+          path: pubgolf-devctrl
+          key: devctrl-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/**') }}
+      - name: Build devctrl
+        if: steps.devctrl-cache.outputs.cache-hit != 'true'
+        run: go build -o pubgolf-devctrl ./tools/cmd/pubgolf-devctrl
+      - name: Get cache week key
+        id: cache-date
+        run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ steps.cache-date.outputs.week }}-${{ hashFiles('web-app/package-lock.json') }}
       - name: Install Web Dependencies
-        run: go run ./tools/cmd/pubgolf-devctrl install web
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: ./pubgolf-devctrl install web
       - name: Run Web Unit Tests
-        run: go run ./tools/cmd/pubgolf-devctrl test web
+        run: ./pubgolf-devctrl test web
       - name: Run Web App Checks
-        run: go run ./tools/cmd/pubgolf-devctrl check web
+        run: ./pubgolf-devctrl check web
       - name: Build Web App
-        run: go run ./tools/cmd/pubgolf-devctrl build web
+        run: ./pubgolf-devctrl build web
       - name: Upload Assets to R2
         if: github.ref == 'refs/heads/main'
         # Repo archived 2025; consider migrating to aws-actions/configure-aws-credentials + aws s3 sync if needed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,17 +130,18 @@ jobs:
           node-version-file: '.node-version'
           cache: npm
           cache-dependency-path: web-app/package-lock.json
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
       - name: Cache devctrl binary
         id: devctrl-cache
         uses: actions/cache@v4
         with:
           path: pubgolf-devctrl
           key: devctrl-${{ runner.os }}-${{ hashFiles('go.sum', 'tools/**') }}
+      - name: Set up Go
+        if: steps.devctrl-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Build devctrl
         if: steps.devctrl-cache.outputs.cache-hit != 'true'
         run: go build -o pubgolf-devctrl ./tools/cmd/pubgolf-devctrl


### PR DESCRIPTION
## Summary
- Cache the devctrl binary across CI runs (keyed on `go.sum` + `tools/**` hash), skipping `go build` on cache hit
- Cache `web-app/node_modules` across CI runs (keyed on `package-lock.json` hash + weekly rotation), skipping `npm ci` on cache hit
- Replace `go run ./tools/cmd/pubgolf-devctrl` with pre-built `./pubgolf-devctrl` binary in all steps

Implements dex task `96dgqq91`.

## Test plan
- [x] CI passes on this PR (first run will be a cache miss — all steps execute)
- [ ] Second CI run on the same branch hits both caches and skips build + install
- [ ] Compare job duration to baseline (~80s → ~20s on full cache hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)