### PR TITLE
feat(web): structured venue description item editor

### DIFF
--- a/web-app/src/lib/components/modals/StageForm.svelte
+++ b/web-app/src/lib/components/modals/StageForm.svelte
@@ -4,21 +4,91 @@
 
 <script lang="ts">
 	import type { UpdateStageRequest } from '$lib/proto/api/v1/admin_pb';
+	import {
+		VenueDescriptionItemType,
+		ScoringCategory,
+		VenueDescriptionItemSchema
+	} from '$lib/proto/api/v1/shared_pb';
 	import type { Venue } from '$lib/proto/api/v1/shared_pb';
 	import { Modal, modalStore } from '@skeletonlabs/skeleton';
-	import { XIcon } from 'lucide-svelte';
+	import { ArrowUpIcon, ArrowDownIcon, TrashIcon, PlusIcon, XIcon } from 'lucide-svelte';
 	import type { ComponentProps } from 'svelte';
 	import type { DisplayError } from '../ErrorBanner.svelte';
 	import ErrorBanner from '../ErrorBanner.svelte';
+	import { create } from '@bufbuild/protobuf';
 
 	export let parent: ComponentProps<Modal>;
 	export let venues: Venue[];
 	export let stage: UpdateStageRequest;
 	export let onSubmit: (data: UpdateStageRequest) => Promise<DisplayError>;
 
+	// Local mutable copy of items for form state.
+	let items: {
+		content: string;
+		itemType: VenueDescriptionItemType;
+		audiences: ScoringCategory[];
+	}[] = (stage.venueDescriptions ?? []).map((item) => ({
+		content: item.content,
+		itemType: item.itemType,
+		audiences: [...item.audiences]
+	}));
+
+	const itemTypeLabels: Record<number, string> = {
+		[VenueDescriptionItemType.DEFAULT]: 'Default',
+		[VenueDescriptionItemType.WARNING]: 'Warning',
+		[VenueDescriptionItemType.RULE]: 'Rule'
+	};
+
+	const audienceLabels: { value: ScoringCategory; label: string }[] = [
+		{ value: ScoringCategory.PUB_GOLF_NINE_HOLE, label: '9-Hole' },
+		{ value: ScoringCategory.PUB_GOLF_FIVE_HOLE, label: '5-Hole' },
+		{ value: ScoringCategory.PUB_GOLF_CHALLENGES, label: 'Challenges' }
+	];
+
 	let error: DisplayError = null;
 	function clearError() {
 		error = null;
+	}
+
+	function addItem() {
+		items = [...items, { content: '', itemType: VenueDescriptionItemType.DEFAULT, audiences: [] }];
+	}
+
+	function removeItem(idx: number) {
+		items.splice(idx, 1);
+		items = items;
+	}
+
+	function moveUp(idx: number) {
+		if (idx <= 0) return;
+		[items[idx - 1], items[idx]] = [items[idx], items[idx - 1]];
+		items = items;
+	}
+
+	function moveDown(idx: number) {
+		if (idx >= items.length - 1) return;
+		[items[idx], items[idx + 1]] = [items[idx + 1], items[idx]];
+		items = items;
+	}
+
+	function toggleAudience(itemIdx: number, category: ScoringCategory) {
+		const auds = items[itemIdx].audiences;
+		const existingIdx = auds.indexOf(category);
+
+		if (existingIdx >= 0) {
+			auds.splice(existingIdx, 1);
+		} else {
+			auds.push(category);
+		}
+
+		items = items;
+	}
+
+	function onItemTypeChange(idx: number) {
+		if (items[idx].itemType !== VenueDescriptionItemType.RULE) {
+			items[idx].audiences = [];
+			items = items;
+		}
 	}
 
 	async function onFormSubmit() {
@@ -26,6 +96,15 @@
 			error = { type: 'Form Validation Error', message: 'Duration value must not be zero.' };
 			return;
 		}
+
+		stage.venueDescriptions = items.map((item) =>
+			create(VenueDescriptionItemSchema, {
+				content: item.content,
+				itemType: item.itemType,
+				audiences: item.audiences
+			})
+		);
+		stage.venueDescription = '';
 
 		const resp = await onSubmit(stage);
 		if (resp) {
@@ -71,15 +150,78 @@
 				bind:value={stage.durationMin}
 			/>
 		</label>
-		<label class="label">
-			<span>Rule</span>
-			<textarea
-				class="textarea min-h-[200px]"
-				required
-				placeholder="Enter rule text..."
-				bind:value={stage.venueDescription}
-			></textarea>
-		</label>
+
+		<div class="space-y-2">
+			<span class="label"><span>Rule Items</span></span>
+
+			{#each items as item, idx (idx)}
+				<div class="card p-3 variant-soft space-y-2">
+					<div class="flex items-center gap-2">
+						<select
+							class="select flex-1"
+							bind:value={item.itemType}
+							on:change={() => onItemTypeChange(idx)}
+						>
+							{#each Object.entries(itemTypeLabels) as [value, label]}
+								<option value={Number(value)}>{label}</option>
+							{/each}
+						</select>
+
+						<button
+							type="button"
+							class="btn btn-icon btn-sm variant-ghost"
+							disabled={idx === 0}
+							on:click={() => moveUp(idx)}
+						>
+							<ArrowUpIcon size={16} />
+						</button>
+						<button
+							type="button"
+							class="btn btn-icon btn-sm variant-ghost"
+							disabled={idx === items.length - 1}
+							on:click={() => moveDown(idx)}
+						>
+							<ArrowDownIcon size={16} />
+						</button>
+						<button
+							type="button"
+							class="btn btn-icon btn-sm variant-ghost-error"
+							on:click={() => removeItem(idx)}
+						>
+							<TrashIcon size={16} />
+						</button>
+					</div>
+
+					<textarea
+						class="textarea min-h-[80px]"
+						placeholder="Enter item text..."
+						bind:value={item.content}
+					></textarea>
+
+					{#if item.itemType === VenueDescriptionItemType.RULE}
+						<div class="flex gap-3 items-center flex-wrap">
+							<span class="text-sm font-medium">Audiences:</span>
+							{#each audienceLabels as { value, label }}
+								<label class="flex items-center gap-1">
+									<input
+										type="checkbox"
+										class="checkbox"
+										checked={item.audiences.includes(value)}
+										on:change={() => toggleAudience(idx, value)}
+									/>
+									<span class="text-sm">{label}</span>
+								</label>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{/each}
+
+			<button type="button" class="btn variant-ghost-primary w-full" on:click={addItem}>
+				<PlusIcon size={16} />
+				<span>Add Item</span>
+			</button>
+		</div>
 	</form>
 
 	<footer class="card-footer {parent.regionFooter}">

--- a/web-app/src/routes/admin/[eventKey]/schedule/+page.svelte
+++ b/web-app/src/routes/admin/[eventKey]/schedule/+page.svelte
@@ -53,7 +53,8 @@
 				venueId: stage.venue?.id,
 				rank: stage.rank,
 				durationMin: stage.durationMin,
-				venueDescription: stage.rule?.venueDescription
+				venueDescription: stage.rule?.venueDescription,
+				venueDescriptions: stage.rule?.venueDescriptions ?? []
 			}),
 			onSubmit: async (data: UpdateStageRequest) => {
 				const rpc = await getAdminServiceClient();
@@ -110,7 +111,13 @@
 							<tr>
 								<td>{stage.venue?.name}</td>
 								<td>{stage.durationMin}</td>
-								<td class="long-text-col">{stage.rule?.venueDescription}</td>
+								<td class="long-text-col"
+									>{#if (stage.rule?.venueDescriptions?.length ?? 0) > 0}{stage.rule
+											?.venueDescriptions?.length} item{(stage.rule?.venueDescriptions?.length ??
+											0) !== 1
+											? 's'
+											: ''}{:else}{stage.rule?.venueDescription || '—'}{/if}</td
+								>
 								<td class="table-cell-fit action-btns text-right">
 									<button
 										type="button"


### PR DESCRIPTION
## Summary
- Replaces single textarea in `StageForm.svelte` with dynamic list of typed rule items
- Each item has: type selector (Default/Warning/Rule), content textarea, conditional audience checkboxes
- Up/down reorder buttons and delete per item
- Schedule table shows item count when structured items exist, falls back to old string display
- Populates `venueDescriptions` on the `UpdateStageRequest` for the backend

**Stacked on** #625

## Test plan
- [x] `pubgolf-devctrl check web` — lint + type-check pass (0 errors, 0 warnings)
- [ ] Smoke test: open admin schedule page, edit a stage, add/remove/reorder items
- [ ] Verify audience checkboxes only appear for Rule type items

🤖 Generated with [Claude Code](https://claude.com/claude-code)