### PR TITLE
fix(GetScoresForCategory): correct post-event status for both leagues

### DIFF
--- a/api/internal/lib/rpc/public/get_scores_for_category.go
+++ b/api/internal/lib/rpc/public/get_scores_for_category.go
@@ -57,16 +57,17 @@ func (s *Server) GetScoresForCategory(ctx context.Context, req *connect.Request[
 	venueIdx := currentStopIndex(es.Schedule, time.Since(est.StartTime))
 	fiveHole := cat == models.ScoringCategoryPubGolfFiveHole
 	required := scoredStages(venueIdx, len(es.Schedule), fiveHole)
-	currentStageNum := currentScoringStageNumber(venueIdx, fiveHole)
+	currentStageNum := currentScoringStageNumber(venueIdx, len(es.Schedule), fiveHole)
+	eventEnded := venueIdx >= len(es.Schedule)
 
 	return connect.NewResponse(&apiv1.GetScoresForCategoryResponse{
 		ScoreBoard: &apiv1.ScoreBoard{
-			Scores: buildCategoryScoreBoard(sc.Scores, required, currentStageNum),
+			Scores: buildCategoryScoreBoard(sc.Scores, required, currentStageNum, eventEnded),
 		},
 	}), nil
 }
 
-func buildCategoryScoreBoard(scores []models.ScoringInput, required int, currentStageNum int64) []*apiv1.ScoreBoard_ScoreBoardEntry {
+func buildCategoryScoreBoard(scores []models.ScoringInput, required int, currentStageNum int64, eventEnded bool) []*apiv1.ScoreBoard_ScoreBoardEntry {
 	sb := make([]*apiv1.ScoreBoard_ScoreBoardEntry, 0, len(scores))
 	rank := uint32(1)
 
@@ -82,14 +83,14 @@ func buildCategoryScoreBoard(scores []models.ScoringInput, required int, current
 			Score:              models.ClampInt32(int(s.TotalPoints)),
 			DisplayScoreSigned: false,
 			Rank:               new(rank),
-			Status:             categoryScoreStatus(s, required, currentStageNum),
+			Status:             categoryScoreStatus(s, required, currentStageNum, eventEnded),
 		})
 	}
 
 	return sb
 }
 
-func categoryScoreStatus(s models.ScoringInput, required int, currentStageNum int64) apiv1.ScoreBoard_ScoreStatus {
+func categoryScoreStatus(s models.ScoringInput, required int, currentStageNum int64, eventEnded bool) apiv1.ScoreBoard_ScoreStatus {
 	req := int64(required)
 	total := s.VerifiedScores + s.UnverifiedScores
 
@@ -101,7 +102,10 @@ func categoryScoreStatus(s models.ScoringInput, required int, currentStageNum in
 		return apiv1.ScoreBoard_SCORE_STATUS_PENDING_VERIFICATION
 	}
 
-	if total == req-1 && s.LatestScoredStageNumber < currentStageNum {
+	// PENDING_SUBMISSION only makes sense mid-event when the player is currently at a
+	// venue and just hasn't submitted that score yet. Once the event has ended any gap
+	// is a permanent INCOMPLETE.
+	if !eventEnded && total == req-1 && s.LatestScoredStageNumber < currentStageNum {
 		return apiv1.ScoreBoard_SCORE_STATUS_PENDING_SUBMISSION
 	}
 
@@ -111,10 +115,15 @@ func categoryScoreStatus(s models.ScoringInput, required int, currentStageNum in
 // currentScoringStageNumber returns the 1-based stage number of the current scoring stage.
 // For nine-hole, every stage is scoring so this is venueIdx+1.
 // For five-hole, only odd-numbered stages are scoring, so this is the latest odd stage number
-// at or before the current venue.
-func currentScoringStageNumber(venueIdx int, fiveHole bool) int64 {
+// at or before the current venue. Once the event has ended (venueIdx >= numVenues) the
+// number is capped at the last real stage so callers don't compare against a phantom stage.
+func currentScoringStageNumber(venueIdx, numVenues int, fiveHole bool) int64 {
 	if venueIdx < 0 {
 		return 0
+	}
+
+	if venueIdx >= numVenues {
+		venueIdx = numVenues - 1
 	}
 
 	if fiveHole {
@@ -129,7 +138,11 @@ func scoredStages(venueIdx, numVenues int, everyOther bool) int {
 		return 0
 	}
 
-	if venueIdx == numVenues {
+	if venueIdx >= numVenues {
+		if everyOther {
+			return (numVenues + 1) / 2
+		}
+
 		return numVenues
 	}
 

--- a/api/internal/lib/rpc/public/get_scores_for_category_test.go
+++ b/api/internal/lib/rpc/public/get_scores_for_category_test.go
@@ -191,6 +191,7 @@ func TestCategoryScoreStatus(t *testing.T) {
 		input           models.ScoringInput
 		required        int
 		currentStageNum int64
+		eventEnded      bool
 		want            apiv1.ScoreBoard_ScoreStatus
 	}{
 		// Nine-hole scenarios (required=5, currentScoringStageNumber=5)
@@ -298,13 +299,115 @@ func TestCategoryScoreStatus(t *testing.T) {
 		// NOTE: ScoringInput counts reflect only scoring holes — the DAO filters
 		// non-scoring holes via the EveryOther parameter in the SQL query. That
 		// property is tested at the dbc level in leaderboard_test.go ("best of five").
+
+		// Post-event nine-hole scenarios (eventEnded=true; required=9, currentStageNum=9)
+		{
+			name:            "nine-hole post-event all verified is finalized",
+			input:           models.ScoringInput{VerifiedScores: 9, UnverifiedScores: 0, LatestScoredStageNumber: 9},
+			required:        9,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_FINALIZED,
+		},
+		{
+			name:            "nine-hole post-event missing middle stage is incomplete",
+			input:           models.ScoringInput{VerifiedScores: 8, UnverifiedScores: 0, LatestScoredStageNumber: 9},
+			required:        9,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_INCOMPLETE,
+		},
+		{
+			name:            "nine-hole post-event missing only last stage is incomplete",
+			input:           models.ScoringInput{VerifiedScores: 8, UnverifiedScores: 0, LatestScoredStageNumber: 8},
+			required:        9,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_INCOMPLETE,
+		},
+
+		// Post-event five-hole scenarios (eventEnded=true; required=5, currentStageNum=9)
+		{
+			name:            "five-hole post-event all verified is finalized",
+			input:           models.ScoringInput{VerifiedScores: 5, UnverifiedScores: 0, LatestScoredStageNumber: 9},
+			required:        5,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_FINALIZED,
+		},
+		{
+			name:            "five-hole post-event all unverified is pending verification",
+			input:           models.ScoringInput{VerifiedScores: 0, UnverifiedScores: 5, LatestScoredStageNumber: 9},
+			required:        5,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_PENDING_VERIFICATION,
+		},
+		{
+			name:            "five-hole post-event missing middle scoring hole is incomplete",
+			input:           models.ScoringInput{VerifiedScores: 4, UnverifiedScores: 0, LatestScoredStageNumber: 9},
+			required:        5,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_INCOMPLETE,
+		},
+		{
+			name:            "five-hole post-event missing only last scoring hole is incomplete",
+			input:           models.ScoringInput{VerifiedScores: 4, UnverifiedScores: 0, LatestScoredStageNumber: 7},
+			required:        5,
+			currentStageNum: 9,
+			eventEnded:      true,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_INCOMPLETE,
+		},
+
+		// Mid-event regression check — at last venue PENDING_SUBMISSION must still work
+		{
+			name:            "nine-hole mid-event at last venue pending submission",
+			input:           models.ScoringInput{VerifiedScores: 8, UnverifiedScores: 0, LatestScoredStageNumber: 8},
+			required:        9,
+			currentStageNum: 9,
+			eventEnded:      false,
+			want:            apiv1.ScoreBoard_SCORE_STATUS_PENDING_SUBMISSION,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := categoryScoreStatus(tc.input, tc.required, tc.currentStageNum)
+			got := categoryScoreStatus(tc.input, tc.required, tc.currentStageNum, tc.eventEnded)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCurrentScoringStageNumber(t *testing.T) {
+	t.Parallel()
+
+	const numVenues = 9
+
+	testCases := []struct {
+		name     string
+		venueIdx int
+		fiveHole bool
+		want     int64
+	}{
+		{name: "pre-event returns zero", venueIdx: -1, fiveHole: false, want: 0},
+		{name: "first venue nine-hole", venueIdx: 0, fiveHole: false, want: 1},
+		{name: "mid-event nine-hole", venueIdx: 4, fiveHole: false, want: 5},
+		{name: "post-event nine-hole caps at last stage", venueIdx: numVenues, fiveHole: false, want: 9},
+		{name: "first venue five-hole at odd stage", venueIdx: 0, fiveHole: true, want: 1},
+		{name: "five-hole at even venue holds last odd", venueIdx: 1, fiveHole: true, want: 1},
+		{name: "five-hole at next odd venue", venueIdx: 2, fiveHole: true, want: 3},
+		{name: "five-hole mid-event at odd venue", venueIdx: 4, fiveHole: true, want: 5},
+		{name: "post-event five-hole caps at last odd stage", venueIdx: numVenues, fiveHole: true, want: 9},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := currentScoringStageNumber(tc.venueIdx, numVenues, tc.fiveHole)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -329,7 +432,7 @@ func TestScoredStages(t *testing.T) {
 		{name: "second venue five-hole unchanged", venueIdx: 1, everyOther: true, want: 1},
 		{name: "third venue five-hole", venueIdx: 2, everyOther: true, want: 2},
 		{name: "mid-event five-hole", venueIdx: 4, everyOther: true, want: 3},
-		{name: "post-event five-hole", venueIdx: numVenues, everyOther: true, want: numVenues},
+		{name: "post-event five-hole", venueIdx: numVenues, everyOther: true, want: 5},
 	}
 
 	for _, tc := range testCases {
@@ -358,7 +461,7 @@ func TestBuildCategoryScoreBoard(t *testing.T) {
 			{PlayerID: p3, Name: "Carol", TotalPoints: 15, VerifiedScores: 5, LatestScoredStageNumber: 5},
 		}
 
-		sb := buildCategoryScoreBoard(scores, 5, 5)
+		sb := buildCategoryScoreBoard(scores, 5, 5, false)
 		require.Len(t, sb, 3)
 
 		assert.Equal(t, uint32(1), sb[0].GetRank())
@@ -374,7 +477,7 @@ func TestBuildCategoryScoreBoard(t *testing.T) {
 			{PlayerID: p1, Name: "Alice", TotalPoints: 10, VerifiedScores: 5, LatestScoredStageNumber: 5},
 		}
 
-		sb := buildCategoryScoreBoard(scores, 5, 5)
+		sb := buildCategoryScoreBoard(scores, 5, 5, false)
 		require.Len(t, sb, 1)
 		assert.Equal(t, uint32(1), sb[0].GetRank())
 	})
@@ -382,7 +485,7 @@ func TestBuildCategoryScoreBoard(t *testing.T) {
 	t.Run("empty scores returns empty board", func(t *testing.T) {
 		t.Parallel()
 
-		sb := buildCategoryScoreBoard(nil, 5, 5)
+		sb := buildCategoryScoreBoard(nil, 5, 5, false)
 		assert.Empty(t, sb)
 	})
 
@@ -395,7 +498,7 @@ func TestBuildCategoryScoreBoard(t *testing.T) {
 			{PlayerID: p1, Name: name, TotalPoints: 10, VerifiedScores: 5, LatestScoredStageNumber: 5},
 		}
 
-		sb := buildCategoryScoreBoard(scores, 5, 5)
+		sb := buildCategoryScoreBoard(scores, 5, 5, false)
 		require.Len(t, sb, 1)
 		assert.Equal(t, p1.String(), sb[0].GetEntityId())
 		assert.Equal(t, name, sb[0].GetLabel())


### PR DESCRIPTION
## Summary

Fixes three independent defects in the category leaderboard's post-event status computation. After an event ends, `currentStopIndex` returns `len(schedule)` — the existing code took several wrong turns when given that value:

- **Defect A (five-hole/SEMI_PRO):** every player showed `INCOMPLETE` after the event ended, even with all 5 verified scores at the required odd-numbered bars. Cause: `scoredStages` early-returned `numVenues` (= 9) regardless of `everyOther`, so `required` was 9 instead of 5.
- **Defect B (nine-hole/PRO):** a player who skipped a middle stage but scored a later one (e.g. missing stop 8, scored stop 9) showed `PENDING_SUBMISSION` instead of `INCOMPLETE`. Cause: `currentScoringStageNumber` returned `numVenues + 1` (= 10), letting the `LatestScoredStageNumber < currentStageNum` test fire spuriously.
- **Defect C (either league):** a player missing only the final stage post-event showed `PENDING_SUBMISSION` instead of `INCOMPLETE`. Cause: `categoryScoreStatus` had no signal that the event was over.

### Fix

- `scoredStages` honors `everyOther` in the end-of-event branch (returns `(numVenues + 1) / 2` for five-hole).
- `currentScoringStageNumber` caps `venueIdx` at `numVenues - 1`, eliminating the phantom stage.
- `categoryScoreStatus` and `buildCategoryScoreBoard` gain an `eventEnded` flag; `PENDING_SUBMISSION` is gated on `!eventEnded`. Mid-event "at the last venue, no submission yet" still works (`venueIdx = numVenues - 1`, so `eventEnded = false`).

### Behavior matrix

| Scenario | eventEnded | Before | After |
|---|---|---|---|
| five-hole post-event, all 5 verified | T | INCOMPLETE | **FINALIZED** |
| five-hole post-event, all 5 unverified | T | INCOMPLETE | **PENDING_VERIFICATION** |
| nine-hole post-event, missing stage 8 (Defect B) | T | PENDING_SUBMISSION | **INCOMPLETE** |
| nine-hole post-event, missing only stage 9 (Defect C) | T | PENDING_SUBMISSION | **INCOMPLETE** |
| nine-hole mid-event AT last venue | F | PENDING_SUBMISSION | PENDING_SUBMISSION (preserved) |

## Test plan

- [x] `pubgolf-devctrl check go` — 0 issues
- [x] `pubgolf-devctrl test` — Go (all packages) + web vitest (14 tests) green; `rpc/public` package up from 186 → 204 tests
- [x] New tests added: `TestCurrentScoringStageNumber`, post-event cases in `TestCategoryScoreStatus`, mid-event-at-last-venue regression case
- [x] Corrected an existing `TestScoredStages` assertion that codified Defect A (`post-event five-hole` was asserting 9, now asserts 5)
- [ ] Manual end-to-end on a finished event:
  - [ ] Five-hole leaderboard: complete player with 5 verified odd-bar scores → `FINALIZED`
  - [ ] Nine-hole leaderboard: player missing stop 8 (scored 1-7, 9) → `INCOMPLETE`
  - [ ] Either league: player missing only the final stage → `INCOMPLETE`
  - [ ] Regression: nine-hole all-verified → `FINALIZED`; mid-event "at the last venue, not submitted" → `PENDING_SUBMISSION`

🤖 Generated with [Claude Code](https://claude.com/claude-code)